### PR TITLE
add pytest config skipping scanning of yencfiles

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = yencfiles


### PR DESCRIPTION
Somewhere between pytest-3.0.3 and 3.2.2, the txt files in yencfiles
started to get picked up and scanned which led to a bunch of errors
like:

```
================================================================ ERRORS ================================================================
___________________________________________ ERROR collecting tests/yencfiles/test_badcrc.txt ___________________________________________
/usr/lib64/python2.7/site-packages/py/_path/common.py:162: in read_text
    return f.read()
/usr/lib64/python2.7/codecs.py:314: in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
E   UnicodeDecodeError: 'utf8' codec can't decode byte 0xa1 in position 189: invalid start byte
```

While there may be a more clever fix, those files shouldn't be getting
scanned anyways.