### PR TITLE
Harden sabyenc against strange article size defined in NZB

### DIFF
--- a/src/sabyenc.c
+++ b/src/sabyenc.c
@@ -560,8 +560,9 @@ PyObject* decode_usenet_chunks(PyObject* self, PyObject* args, PyObject* kwds) {
         return NULL;
     }
 
-    // If we did not get a size, we need to calculate it (slower, but safer)
-    if(num_bytes_reserved <= 0) {
+    // If we got a strange article size, we need to calculate it (slower, but safer)
+    if ((num_bytes_reserved <= 0) || (num_bytes_reserved >= MAX_RESERVED_BYTES)) {
+        num_bytes_reserved=0;
         lp_max = (int)PyList_Size(Py_input_list);
         for(lp = 0; lp < lp_max; lp++) {
             num_bytes_reserved += (int)PyString_Size(PyList_GetItem(Py_input_list, lp));

--- a/src/sabyenc.c
+++ b/src/sabyenc.c
@@ -562,7 +562,7 @@ PyObject* decode_usenet_chunks(PyObject* self, PyObject* args, PyObject* kwds) {
 
     // If we got a strange article size, we need to calculate it (slower, but safer)
     if ((num_bytes_reserved <= 0) || (num_bytes_reserved >= MAX_RESERVED_BYTES)) {
-        num_bytes_reserved=0;
+        num_bytes_reserved = 0;
         lp_max = (int)PyList_Size(Py_input_list);
         for(lp = 0; lp < lp_max; lp++) {
             num_bytes_reserved += (int)PyString_Size(PyList_GetItem(Py_input_list, lp));

--- a/src/sabyenc.h
+++ b/src/sabyenc.h
@@ -42,6 +42,8 @@
 #define TAB         0x09
 #define SPACE       0x20
 #define DOT         0x2e
+// 10MB should be enough for any article, as 1MB is the common maximum
+#define MAX_RESERVED_BYTES     10111000
 
 /* Customized types */
 typedef unsigned long long uLong;

--- a/src/sabyenc.h
+++ b/src/sabyenc.h
@@ -42,7 +42,9 @@
 #define TAB         0x09
 #define SPACE       0x20
 #define DOT         0x2e
-// 10MB should be enough for any article, as 1MB is the common maximum
+
+/* 10MB should be enough for any article,
+   as 1MB is the common maximum */
 #define MAX_RESERVED_BYTES     10111000
 
 /* Customized types */


### PR DESCRIPTION
Harden sabyenc against strange article size defined in NZB ("SEGMENT BYTES" negative or too big value)

Solves OoM https://github.com/sabnzbd/sabyenc/issues/13
Does not solve https://github.com/sabnzbd/sabyenc/issues/14 (too small SEGMENT BYTES)