### PR TITLE
Fix building on OpenBSD

### DIFF
--- a/src/yencode/common.h
+++ b/src/yencode/common.h
@@ -39,7 +39,7 @@
 #include <stdlib.h> // MSVC ARM64 seems to need this
 #define ALIGN_ALLOC(buf, len, align) *(void**)&(buf) = _aligned_malloc((len), align)
 #define ALIGN_FREE _aligned_free
-#elif defined(__cplusplus) && __cplusplus >= 201100 && !(defined(_MSC_VER) && (defined(__clang__) || defined(_M_ARM64) || defined(_M_ARM))) && !defined(__APPLE__)
+#elif defined(__cplusplus) && __cplusplus >= 201100 && !(defined(_MSC_VER) && (defined(__clang__) || defined(_M_ARM64) || defined(_M_ARM))) && !defined(__APPLE__) && !defined(__OpenBSD__)
 // C++11 method
 // len needs to be a multiple of alignment, although it sometimes works if it isn't...
 #include <cstdlib>


### PR DESCRIPTION
Building of sabyenc-5.1.0 fails on OpenBSD current (amd64) with:

```
In file included from src/yencode/encoder_sse2.cc:4:
src/yencode/encoder_sse_base.h:33:5: error: use of undeclared identifier 'aligned_alloc'
    ALIGN_ALLOC(lookups, sizeof(*lookups), 16);
    ^
src/yencode/common.h:46:56: note: expanded from macro 'ALIGN_ALLOC'
#define ALIGN_ALLOC(buf, len, align) *(void**)&(buf) = aligned_alloc(align, ((len) + (align)-1) & ~((align)-1))
                                                       ^
1 error generated.
```

With this diff building is successful, and all tests pass.