### PR TITLE
Implement compile-time checks for flags/includes/defines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def autoconf_check(
 
 
 class SAByEncBuild(build_ext):
-    def build_extension(self, ext):
+    def build_extension(self, ext: Extension):
         # Try to determine the architecture to build for
         machine = platform.machine().lower()
         IS_X86 = machine in ["i386", "i686", "x86", "x86_64", "x64", "amd64"]
@@ -111,8 +111,10 @@ class SAByEncBuild(build_ext):
             # gcc before 4.7 called it "-std=c++0x"
             if autoconf_check(self.compiler, flag_check="-std=c++11"):
                 cflags.append("-std=c++11")
+                ext.extra_compile_args.append("-std=c++11")
             elif autoconf_check(self.compiler, flag_check="-std=c++0x"):
                 cflags.append("-std=c++0x")
+                ext.extra_compile_args.append("-std=c++0x")
             else:
                 log.info("C++11 flag not available")
 

--- a/setup.py
+++ b/setup.py
@@ -123,10 +123,12 @@ class SAByEncBuild(build_ext):
             # macOS M1 do not need any flags, they support everything
             if IS_ARM and not IS_MACOS:
                 if not autoconf_check(self.compiler, include_check="sys/auxv.h"):
-                    log.info("sys/auxv.h not available, setting UNSUPPORTED_PLATFORM_ARM")
-                    ext.define_macros.append(("UNSUPPORTED_PLATFORM_ARM", "1"))
-                    gcc_macros.append(("UNSUPPORTED_PLATFORM_ARM", "1"))
-                    IS_ARM = False
+                    # We only tested this for GCC, might still be valid on MS-ARM compiler (see #38)
+                    if autoconf_check(self.compiler, define_check="__GNUC__"):
+                        log.info("On GGC and sys/auxv.h not available, setting UNSUPPORTED_PLATFORM_ARM")
+                        ext.define_macros.append(("UNSUPPORTED_PLATFORM_ARM", "1"))
+                        gcc_macros.append(("UNSUPPORTED_PLATFORM_ARM", "1"))
+                        IS_ARM = False
                 if not autoconf_check(self.compiler, define_check="__aarch64__"):
                     log.info("__aarch64__ not available, disabling 64bit extensions")
                     IS_AARCH64 = False

--- a/src/yencode/common.h
+++ b/src/yencode/common.h
@@ -34,6 +34,9 @@
 #define PLATFORM_ARM 1
 #endif
 
+#if defined(UNSUPPORTED_PLATFORM_ARM)
+#undef PLATFORM_ARM
+#endif
 
 #include <stdlib.h>
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)


### PR DESCRIPTION
@animetosho What do you think about my attempt? It seems to work quite wel!

Only thing remains is the `sys/auxv.h` problem on ARMv5. Just setting `IS_ARM = False` is not enough. 
Probably we need to `#undef PLATFORM_ARM`, right?
Would you do this with external detection from the `setup.py` or just detect it in the C code and manage it there?


Closes #37