### PR TITLE
Add VPCLMULQDQ support for CRC calc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ class SAByEncBuild(build_ext):
         # Determine compiler flags
         gcc_arm_neon_flags = []
         gcc_arm_crc_flags = []
+        gcc_vpclmulqdq_flags = []
         gcc_macros = []
         if self.compiler.compiler_type == "msvc":
             # LTCG not enabled due to issues seen with code generation where
@@ -147,6 +148,9 @@ class SAByEncBuild(build_ext):
                 log.info("==> Detected x32 platform, setting CRCUTIL_USE_ASM=0")
                 ext.define_macros.append(("CRCUTIL_USE_ASM", "0"))
                 gcc_macros.append(("CRCUTIL_USE_ASM", "0"))
+            
+            if IS_X86 and autoconf_check(self.compiler, flag_check="-mvpclmulqdq"):
+                gcc_vpclmulqdq_flags = ["-mavx2", "-mvpclmulqdq", "-mpclmul"]
 
         srcdeps_crc_common = ["src/yencode/common.h", "src/yencode/crc_common.h", "src/yencode/crc.h"]
         srcdeps_dec_common = ["src/yencode/common.h", "src/yencode/decoder_common.h", "src/yencode/decoder.h"]
@@ -193,7 +197,7 @@ class SAByEncBuild(build_ext):
             {
                 "sources": ["src/yencode/crc_folding_256.cc"],
                 "depends": srcdeps_crc_common,
-                "gcc_x86_flags": ["-mavx2", "-mvpclmulqdq", "-mpclmul"] if IS_X86 and autoconf_check(self.compiler, flag_check="-mvpclmulqdq") else [],
+                "gcc_x86_flags": gcc_vpclmulqdq_flags,
                 "msvc_x86_flags": ["/arch:AVX2"],
             },
             {

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,12 @@ class SAByEncBuild(build_ext):
                 "gcc_x86_flags": ["-mssse3", "-msse4.1", "-mpclmul"],
             },
             {
+                "sources": ["src/yencode/crc_folding_256.cc"],
+                "depends": srcdeps_crc_common,
+                "gcc_x86_flags": ["-mavx2", "-mvpclmulqdq", "-mpclmul"] if IS_X86 and autoconf_check(self.compiler, flag_check="-mvpclmulqdq") else [],
+                "msvc_x86_flags": ["/arch:AVX2"],
+            },
+            {
                 "sources": ["src/yencode/encoder_avx.cc"],
                 "depends": srcdeps_enc_common + ["encoder_sse_base.h"],
                 "gcc_x86_flags": ["-mavx", "-mpopcnt"],

--- a/src/yencode/common.h
+++ b/src/yencode/common.h
@@ -250,13 +250,6 @@ enum YEncDecIsaLevel {
 # endif
 #endif
 
-#ifdef _MSC_VER
-# define _cpuid1(ar) __cpuid(ar, 1)
-#else
-# include <cpuid.h>
-# define _cpuid1(ar) __cpuid(1, ar[0], ar[1], ar[2], ar[3])
-#endif
-
 int cpu_supports_isa();
 #endif // PLATFORM_X86
 

--- a/src/yencode/crc.cc
+++ b/src/yencode/crc.cc
@@ -26,8 +26,13 @@ uint32_t do_crc32_zeros(uint32_t crc1, size_t len) {
 }
 
 void crc_clmul_set_funcs(crc_func *);
+void crc_clmul256_set_funcs(crc_func *);
 
 void crc_arm_set_funcs(crc_func *);
+
+#ifdef PLATFORM_X86
+int cpu_supports_crc_isa();
+#endif
 
 #if defined(PLATFORM_ARM) && defined(_WIN32)
 # define WIN32_LEAN_AND_MEAN
@@ -61,9 +66,10 @@ void crc_init() {
     // instance never deleted... oh well...
 
 #ifdef PLATFORM_X86
-    int flags[4];
-    _cpuid1(flags);
-    if((flags[2] & 0x80202) == 0x80202) // SSE4.1 + SSSE3 + CLMUL
+    int support = cpu_supports_crc_isa();
+    if(support == 2)
+        crc_clmul256_set_funcs(&_do_crc32_incremental);
+    else if(support == 1)
         crc_clmul_set_funcs(&_do_crc32_incremental);
 #endif
 #ifdef PLATFORM_ARM

--- a/src/yencode/crc_folding.cc
+++ b/src/yencode/crc_folding.cc
@@ -135,33 +135,6 @@ ALIGN_TO(16, static const unsigned crc_mask[4]) = {
     0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF
 };
 
-static __m128i reverse_bits_epi8(__m128i src) {
-#if defined(__GFNI__) && defined(YENC_BUILD_NATIVE) && YENC_BUILD_NATIVE!=0
-    return _mm_gf2p8affine_epi64_epi8(src, _mm_set_epi32(
-      0x80402010, 0x08040201,
-      0x80402010, 0x08040201
-    ), 0);
-#else
-    __m128i xmm_t0 = _mm_and_si128(src, _mm_set1_epi8(0x0f));
-    __m128i xmm_t1 = _mm_and_si128(_mm_srli_epi16(src, 4), _mm_set1_epi8(0x0f));
-    xmm_t0 = _mm_shuffle_epi8(_mm_set_epi8(
-      -16, 112, -80, 48, -48, 80, -112, 16, -32, 96, -96, 32, -64, 64, -128, 0
-      //0xf0, 0x70, 0xb0, 0x30, 0xd0, 0x50, 0x90, 0x10, 0xe0, 0x60, 0xa0, 0x20, 0xc0, 0x40, 0x80, 0
-    ), xmm_t0);
-    xmm_t1 = _mm_shuffle_epi8(_mm_set_epi8(
-      15, 7, 11, 3, 13, 5, 9, 1, 14, 6, 10, 2, 12, 4, 8, 0
-    ), xmm_t1);
-    return _mm_or_si128(xmm_t0, xmm_t1);
-#endif
-}
-
-#ifdef _MSC_VER
-// because MSVC doesn't use BSWAP unless you specifically tell it to...
-# include <stdlib.h>
-# define BSWAP32 _byteswap_ulong
-#else
-# define BSWAP32(n) ((((n)&0xff)<<24) | (((n)&0xff00)<<8) | (((n)&0xff0000)>>8) | (((n)&0xff000000)>>24))
-#endif
 
 static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
     unsigned long algn_diff;
@@ -170,23 +143,17 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
     // TODO: consider calculating this via a LUT instead (probably faster)
     // info from https://www.reddit.com/r/ReverseEngineering/comments/2zwhl3/mystery_constant_0x9db42487_in_intels_crc32ieee/
     // firstly, calculate: xmm_crc0 = (intial * 0x487b9c8a) mod 0x104c11db7, where 0x487b9c8a = inverse(1<<512) mod 0x104c11db7
+    xmm_t0 = _mm_cvtsi32_si128(~initial);
 
-    // reverse input bits + load into XMM register
-    uint32_t init_t = BSWAP32(initial);
-    xmm_t0 = reverse_bits_epi8(_mm_cvtsi32_si128(~init_t));
-
-    xmm_t0 = _mm_clmulepi64_si128(xmm_t0, _mm_cvtsi32_si128(0x487b9c8a), 0);
-    xmm_t1 = _mm_and_si128(xmm_t0, _mm_set_epi32(-1,-1,-1,0)); // shifted up by 32bits to avoid shifts by using clmul's capability to select top 64bits instead
+    xmm_t0 = _mm_clmulepi64_si128(xmm_t0, _mm_set_epi32(0, 0, 0xa273bc24, 0), 0);  // reverse(0x487b9c8a)<<1 == 0xa273bc24
     xmm_t2 = _mm_set_epi32( // polynomial reduction factors
-      0, 0x04c11db7, // G*
-      1, 0x04d101df  // Q+
+      1, 0xdb710640, // G* = 0x04c11db7
+      0, 0xf7011641  // Q+ = 0x04d101df  (+1 to save an additional xor operation)
     );
-    xmm_t1 = _mm_clmulepi64_si128(xmm_t1, xmm_t2, 0);
-    xmm_t1 = _mm_clmulepi64_si128(xmm_t1, xmm_t2, 0x11);
+    xmm_t1 = _mm_clmulepi64_si128(xmm_t0, xmm_t2, 0);
+    xmm_t1 = _mm_clmulepi64_si128(xmm_t1, xmm_t2, 0x10);
 
-    __m128i xmm_crc0 = _mm_xor_si128(xmm_t0, xmm_t1);
-    // reverse bits
-    xmm_crc0 = _mm_shuffle_epi8(reverse_bits_epi8(xmm_crc0), _mm_set_epi32(-1,-1,-1,0x00010203));
+    __m128i xmm_crc0 = _mm_srli_si128(_mm_xor_si128(xmm_t0, xmm_t1), 8);
 
     __m128i xmm_crc1 = _mm_setzero_si128();
     __m128i xmm_crc2 = _mm_setzero_si128();
@@ -196,7 +163,8 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
     if (len < 16) {
         if (len == 0)
             return initial;
-        xmm_crc_part = _mm_loadu_si128((__m128i *)src);
+        xmm_crc_part = _mm_setzero_si128();
+        memcpy(&xmm_crc_part, src, len);
         goto partial;
     }
 
@@ -211,7 +179,7 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
             &xmm_crc_part);
     }
 
-    while ((len -= 64) >= 0) {
+    while (len >= 64) {
         xmm_t0 = _mm_load_si128((__m128i *)src);
         xmm_t1 = _mm_load_si128((__m128i *)src + 1);
         xmm_t2 = _mm_load_si128((__m128i *)src + 2);
@@ -235,13 +203,11 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
 #endif
 
         src += 64;
+        len -= 64;
     }
 
-    /*
-     * len = num bytes left - 64
-     */
-    if (len + 16 >= 0) {
-        len += 16;
+    if (len >= 48) {
+        len -= 48;
 
         xmm_t0 = _mm_load_si128((__m128i *)src);
         xmm_t1 = _mm_load_si128((__m128i *)src + 1);
@@ -266,8 +232,8 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
             goto done;
 
         xmm_crc_part = _mm_load_si128((__m128i *)src + 3);
-    } else if (len + 32 >= 0) {
-        len += 32;
+    } else if (len >= 32) {
+        len -= 32;
 
         xmm_t0 = _mm_load_si128((__m128i *)src);
         xmm_t1 = _mm_load_si128((__m128i *)src + 1);
@@ -290,8 +256,8 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
             goto done;
 
         xmm_crc_part = _mm_load_si128((__m128i *)src + 2);
-    } else if (len + 48 >= 0) {
-        len += 48;
+    } else if (len >= 16) {
+        len -= 16;
 
         xmm_t0 = _mm_load_si128((__m128i *)src);
 
@@ -310,7 +276,6 @@ static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
 
         xmm_crc_part = _mm_load_si128((__m128i *)src + 1);
     } else {
-        len += 64;
         if (len == 0)
             goto done;
         xmm_crc_part = _mm_load_si128((__m128i *)src);

--- a/src/yencode/crc_folding_256.cc
+++ b/src/yencode/crc_folding_256.cc
@@ -1,0 +1,230 @@
+// 256-bit version of crc_folding
+
+#include "crc_common.h"
+ 
+#if !defined(YENC_DISABLE_AVX256) && ((defined(__VPCLMULQDQ__) && defined(__AVX2__) && defined(__PCLMUL__)) || (defined(_MSC_VER) && _MSC_VER >= 1920 && defined(PLATFORM_X86)))
+#include <inttypes.h>
+#include <immintrin.h>
+
+
+#if defined(__AVX512VL__) && defined(YENC_BUILD_NATIVE) && YENC_BUILD_NATIVE!=0
+# define ENABLE_AVX512 1
+#endif
+
+static __m256i do_one_fold(__m256i src, __m256i data) {
+    const __m256i fold4 = _mm256_set_epi32(
+        0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596,
+        0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596
+    );
+#ifdef ENABLE_AVX512
+    return _mm256_ternarylogic_epi32(
+      _mm256_clmulepi64_epi128(src, fold4, 0x01),
+      _mm256_clmulepi64_epi128(src, fold4, 0x10),
+      data,
+      0x96
+    );
+#else
+    return _mm256_xor_si256(data, _mm256_xor_si256(
+      _mm256_clmulepi64_epi128(src, fold4, 0x01),
+      _mm256_clmulepi64_epi128(src, fold4, 0x10)
+    ));
+#endif
+}
+
+ALIGN_TO(32, static const uint8_t  pshufb_rot_table[]) = {
+    0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,
+    16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31
+};
+// _mm256_castsi128_si256, but upper is defined to be 0
+#if (defined(__clang__) && __clang_major__ >= 5 && (!defined(__APPLE__) || __clang_major__ >= 7)) || (defined(__GNUC__) && __GNUC__ >= 10)
+// intrinsic unsupported in GCC 9 and MSVC < 2017
+# define zext128_256 _mm256_zextsi128_si256
+#else
+// technically a cast is incorrect, due to upper 128 bits being undefined, but should usually work fine
+// alternative may be `_mm256_set_m128i(_mm_setzero_si128(), v)` but unsupported on GCC < 7, and most compilers generate a VINSERTF128 instruction for it
+# ifdef __OPTIMIZE__
+#  define zext128_256 _mm256_castsi128_si256
+# else
+#  define zext128_256(x) _mm256_inserti128_si256(_mm256_setzero_si256(), x, 0)
+# endif
+#endif
+
+#ifdef ENABLE_AVX512
+# define MM256_BLENDV(a, b, m) _mm256_ternarylogic_epi32(a, b, m, 0xd8)
+# define MM_2XOR(a, b, c) _mm_ternarylogic_epi32(a, b, c, 0x96)
+#else
+# define MM256_BLENDV _mm256_blendv_epi8
+# define MM_2XOR(a, b, c) _mm_xor_si128(_mm_xor_si128(a, b), c)
+#endif
+
+static void partial_fold(const size_t len, __m256i *crc0, __m256i *crc1, __m256i crc_part) {
+    __m256i shuf = _mm256_broadcastsi128_si256(_mm_loadu_si128((__m128i*)(pshufb_rot_table + (len&15))));
+    __m256i mask = _mm256_cmpgt_epi8(shuf, _mm256_set1_epi8(15));
+    
+    *crc0 = _mm256_shuffle_epi8(*crc0, shuf);
+    *crc1 = _mm256_shuffle_epi8(*crc1, shuf);
+    crc_part = _mm256_shuffle_epi8(crc_part, shuf);
+    
+    __m256i crc_out = _mm256_permute2x128_si256(*crc0, *crc0, 0x08);  // move bottom->top
+    __m256i crc01, crc1p;
+    if(len >= 16) {
+        crc_out = MM256_BLENDV(crc_out, *crc0, mask);
+        crc01 = *crc1;
+        crc1p = crc_part;
+        *crc0 = _mm256_permute2x128_si256(*crc0, *crc1, 0x21);
+        *crc1 = _mm256_permute2x128_si256(*crc1, crc_part, 0x21);
+        crc_part = zext128_256(_mm256_extracti128_si256(crc_part, 1));
+    } else {
+        crc_out = _mm256_and_si256(crc_out, mask);
+        crc01 = _mm256_permute2x128_si256(*crc0, *crc1, 0x21);
+        crc1p = _mm256_permute2x128_si256(*crc1, crc_part, 0x21);
+    }
+    
+    *crc0 = MM256_BLENDV(*crc0, crc01, mask);
+    *crc1 = MM256_BLENDV(*crc1, crc1p, mask);
+    
+    *crc1 = do_one_fold(crc_out, *crc1);
+}
+
+
+ALIGN_TO(16, static const unsigned crc_k[]) = {
+    0xccaa009e, 0x00000000, /* rk1 */
+    0x751997d0, 0x00000001, /* rk2 */
+    0xccaa009e, 0x00000000, /* rk5 */
+    0x63cd6124, 0x00000001, /* rk6 */
+    0xf7011641, 0x00000000, /* rk7 */
+    0xdb710640, 0x00000001  /* rk8 */
+};
+
+
+static uint32_t crc_fold(const unsigned char *src, long len, uint32_t initial) {
+    // info from https://www.reddit.com/r/ReverseEngineering/comments/2zwhl3/mystery_constant_0x9db42487_in_intels_crc32ieee/
+    // firstly, calculate: xmm_crc0 = (intial * 0x487b9c8a) mod 0x104c11db7, where 0x487b9c8a = inverse(1<<512) mod 0x104c11db7
+    __m128i xmm_t0 = _mm_cvtsi32_si128(~initial);
+    
+    xmm_t0 = _mm_clmulepi64_si128(xmm_t0, _mm_set_epi32(0, 0, 0xa273bc24, 0), 0);  // reverse(0x487b9c8a)<<1 == 0xa273bc24
+    __m128i reduction = _mm_set_epi32( // polynomial reduction factors
+      1, 0xdb710640, // G* = 0x04c11db7
+      0, 0xf7011641  // Q+ = 0x04d101df  (+1 to save an additional xor operation)
+    );
+    __m128i xmm_t1 = _mm_clmulepi64_si128(xmm_t0, reduction, 0);
+    xmm_t1 = _mm_clmulepi64_si128(xmm_t1, reduction, 0x10);
+    
+    xmm_t0 = _mm_srli_si128(_mm_xor_si128(xmm_t0, xmm_t1), 8);
+    __m256i crc0 = zext128_256(xmm_t0);
+    __m256i crc1 = _mm256_setzero_si256();
+    
+    if (len < 32) {
+        if (len == 0)
+            return initial;
+        __m256i crc_part = _mm256_setzero_si256();
+        memcpy(&crc_part, src, len);
+        partial_fold(len, &crc0, &crc1, crc_part);
+    } else {
+        uintptr_t algn_diff = (0 - (uintptr_t)src) & 0x1F;
+        if (algn_diff) {
+            partial_fold(algn_diff, &crc0, &crc1, _mm256_loadu_si256((__m256i *)src));
+            src += algn_diff;
+            len -= algn_diff;
+        }
+        
+        while (len >= 64) {
+            crc0 = do_one_fold(crc0, _mm256_load_si256((__m256i*)src));
+            crc1 = do_one_fold(crc1, _mm256_load_si256((__m256i*)src + 1));
+            src += 64;
+            len -= 64;
+        }
+        
+        if (len >= 32) {
+            __m256i old = crc1;
+            crc1 = do_one_fold(crc0, _mm256_load_si256((__m256i*)src));
+            crc0 = old;
+            
+            len -= 32;
+            src += 32;
+        }
+        
+        if(len != 0) {
+            partial_fold(len, &crc0, &crc1, _mm256_load_si256((__m256i *)src));
+        }
+    }
+    
+    const __m128i xmm_mask = _mm_set_epi32(-1,-1,-1,0);
+    __m128i x_tmp0, x_tmp1, x_tmp2, crc_fold;
+    
+    __m128i xmm_crc0 = _mm256_castsi256_si128(crc0);
+    __m128i xmm_crc1 = _mm256_extracti128_si256(crc0, 1);
+    __m128i xmm_crc2 = _mm256_castsi256_si128(crc1);
+    __m128i xmm_crc3 = _mm256_extracti128_si256(crc1, 1);
+
+    /*
+     * k1
+     */
+    crc_fold = _mm_load_si128((__m128i *)crc_k);
+
+    x_tmp0 = _mm_clmulepi64_si128(xmm_crc0, crc_fold, 0x10);
+    xmm_crc0 = _mm_clmulepi64_si128(xmm_crc0, crc_fold, 0x01);
+    xmm_crc1 = MM_2XOR(xmm_crc1, x_tmp0, xmm_crc0);
+
+    x_tmp1 = _mm_clmulepi64_si128(xmm_crc1, crc_fold, 0x10);
+    xmm_crc1 = _mm_clmulepi64_si128(xmm_crc1, crc_fold, 0x01);
+    xmm_crc2 = MM_2XOR(xmm_crc2, x_tmp1, xmm_crc1);
+
+    x_tmp2 = _mm_clmulepi64_si128(xmm_crc2, crc_fold, 0x10);
+    xmm_crc2 = _mm_clmulepi64_si128(xmm_crc2, crc_fold, 0x01);
+    xmm_crc3 = MM_2XOR(xmm_crc3, x_tmp2, xmm_crc2);
+
+    /*
+     * k5
+     */
+    crc_fold = _mm_load_si128((__m128i *)crc_k + 1);
+
+    xmm_crc0 = xmm_crc3;
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0);
+    xmm_crc0 = _mm_srli_si128(xmm_crc0, 8);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc0);
+
+    xmm_crc0 = xmm_crc3;
+    xmm_crc3 = _mm_slli_si128(xmm_crc3, 4);
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0x10);
+#ifdef ENABLE_AVX512
+    //xmm_crc3 = _mm_maskz_xor_epi32(14, xmm_crc3, xmm_crc0);
+    xmm_crc3 = _mm_ternarylogic_epi32(xmm_crc3, xmm_crc0, xmm_mask, 0x28);
+#else
+    xmm_crc0 = _mm_and_si128(xmm_crc0, xmm_mask);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc0);
+#endif
+
+    /*
+     * k7
+     */
+    xmm_crc1 = xmm_crc3;
+    crc_fold = _mm_load_si128((__m128i *)crc_k + 2);
+
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0);
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0x10);
+#ifdef ENABLE_AVX512
+    xmm_crc3 = _mm_ternarylogic_epi32(xmm_crc3, xmm_crc1, xmm_crc1, 0xC3); // NOT(xmm_crc3 ^ xmm_crc1)
+#else
+    xmm_crc1 = _mm_xor_si128(xmm_crc1, xmm_mask);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc1);
+#endif
+    return _mm_extract_epi32(xmm_crc3, 2);
+}
+
+static uint32_t do_crc32_incremental_clmul(const void *data, size_t length, uint32_t init) {
+    return crc_fold((const unsigned char*)data, (long)length, init);
+}
+
+void crc_clmul256_set_funcs(crc_func *_do_crc32_incremental) {
+    *_do_crc32_incremental = &do_crc32_incremental_clmul;
+}
+#else
+void crc_clmul_set_funcs(crc_func *_do_crc32_incremental);
+void crc_clmul256_set_funcs(crc_func *_do_crc32_incremental) {
+    crc_clmul_set_funcs(_do_crc32_incremental);
+}
+#endif
+

--- a/src/yencode/platform.cc
+++ b/src/yencode/platform.cc
@@ -56,6 +56,7 @@ bool cpu_supports_neon() {
 
 #ifdef PLATFORM_X86
 #ifdef _MSC_VER
+# define _cpuid1(ar) __cpuid(ar, 1)
 # define _cpuid1x(ar) __cpuid(ar, 0x80000001)
 # if _MSC_VER >= 1600
 #  define _cpuidX __cpuidex
@@ -67,6 +68,8 @@ bool cpu_supports_neon() {
 #  define _GET_XCR() 0
 # endif
 #else
+# include <cpuid.h>
+# define _cpuid1(ar) __cpuid(1, ar[0], ar[1], ar[2], ar[3])
 # define _cpuid1x(ar) __cpuid(0x80000001, ar[0], ar[1], ar[2], ar[3])
 # define _cpuidX(ar, eax, ecx) __cpuid_count(eax, ecx, ar[0], ar[1], ar[2], ar[3])
 static inline int _GET_XCR() {
@@ -113,8 +116,6 @@ int cpu_supports_isa() {
         // AMD Bobcat with slow SSSE3 instructions - pretend it doesn't exist
         return ret | ISA_LEVEL_SSE2;
 
-    // Jaguar/Puma performance unkown (slowish PSHUFB/PBLENDVB)
-
     if((flags[2] & 0x200) == 0x200) { // SSSE3
         if(family == 6 && (model == 0x5c || model == 0x5f || model == 0x7a || model == 0x9c))
             // Intel Goldmont/plus / Tremont with slow PBLENDVB
@@ -143,6 +144,26 @@ int cpu_supports_isa() {
         return ret | ISA_LEVEL_SSSE3;
     }
     return ret | ISA_LEVEL_SSE2;
+}
+
+int cpu_supports_crc_isa() {
+    int flags[4];
+    _cpuid1(flags);
+    
+    if((flags[2] & 0x80202) == 0x80202) { // SSE4.1 + SSSE3 + CLMUL
+        if((flags[2] & 0x18000000) == 0x18000000) { // OSXSAVE + AVX
+            int xcr = _GET_XCR() & 0xff; // ignore unused bits
+            if((xcr & 6) == 6) { // AVX enabled
+                int cpuInfo[4];
+                _cpuidX(cpuInfo, 7, 0);
+                if((cpuInfo[1] & 0x20) == 0x20 && (cpuInfo[2] & 0x400) == 0x400) { // AVX2 + VPCLMULQDQ
+                    return 2;
+                }
+            }
+        }
+        return 1;
+    }
+    return 0;
 }
 
 #endif // PLATFORM_X86


### PR DESCRIPTION
Adds the ability to compute CRC using AVX2+[VPCLMULQDQ](https://en.wikipedia.org/wiki/AVX-512#VPCLMULQDQ) feature.

Up to 2x CRC performance on CPUs with the feature (AMD Zen3, Intel Ice Lake or later).