### PR TITLE
Enable VBMI2 optimisations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ class SAByEncBuild(build_ext):
         gcc_arm_neon_flags = []
         gcc_arm_crc_flags = []
         gcc_vpclmulqdq_flags = []
+        gcc_vbmi2_flags = []
         gcc_macros = []
         if self.compiler.compiler_type == "msvc":
             # LTCG not enabled due to issues seen with code generation where
@@ -151,6 +152,9 @@ class SAByEncBuild(build_ext):
             
             if IS_X86 and autoconf_check(self.compiler, flag_check="-mvpclmulqdq"):
                 gcc_vpclmulqdq_flags = ["-mavx2", "-mvpclmulqdq", "-mpclmul"]
+            
+            if IS_X86 and autoconf_check(self.compiler, flag_check="-mavx512vbmi2"):
+                gcc_vbmi2_flags = ["-mavx512vbmi2", "-mavx512vl", "-mavx512bw", "-mpopcnt", "-mbmi", "-mbmi2", "-mlzcnt"]
 
         srcdeps_crc_common = ["src/yencode/common.h", "src/yencode/crc_common.h", "src/yencode/crc.h"]
         srcdeps_dec_common = ["src/yencode/common.h", "src/yencode/decoder_common.h", "src/yencode/decoder.h"]
@@ -223,6 +227,18 @@ class SAByEncBuild(build_ext):
                 "depends": srcdeps_dec_common + ["decoder_avx2_base.h"],
                 "gcc_x86_flags": ["-mavx2", "-mpopcnt", "-mbmi", "-mbmi2", "-mlzcnt"],
                 "msvc_x86_flags": ["/arch:AVX2"],
+            },
+            {
+                "sources": ["src/yencode/encoder_vbmi2.cc"],
+                "depends": srcdeps_enc_common + ["encoder_avx_base.h"],
+                "gcc_x86_flags": gcc_vbmi2_flags,
+                "msvc_x86_flags": ["/arch:AVX512"],
+            },
+            {
+                "sources": ["src/yencode/decoder_vbmi2.cc"],
+                "depends": srcdeps_dec_common + ["decoder_avx2_base.h"],
+                "gcc_x86_flags": gcc_vbmi2_flags,
+                "msvc_x86_flags": ["/arch:AVX512"],
             },
             {
                 "sources": ["src/yencode/encoder_neon.cc"],

--- a/src/yencode/common.h
+++ b/src/yencode/common.h
@@ -267,7 +267,7 @@ int cpu_supports_isa();
 
 
 // GCC 8/9/10(dev) fails to optimize cases where KNOT should be used, so use intrinsic explicitly; Clang 6+ has no issue, but Clang 6/7 doesn't have the intrinsic; MSVC 2019 also fails and lacks the intrinsic
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if (defined(__GNUC__) && __GNUC__ >= 7) || (defined(_MSC_VER) && _MSC_VER >= 1924)
 # define KNOT16 _knot_mask16
 # define KNOT32 _knot_mask32
 #else

--- a/src/yencode/common.h
+++ b/src/yencode/common.h
@@ -253,8 +253,6 @@ enum YEncDecIsaLevel {
 int cpu_supports_isa();
 #endif // PLATFORM_X86
 
-const char* simd_detected();
-
 #include <string.h>
 
 #if !defined(_MSC_VER) || defined(_STDINT) || _MSC_VER >= 1900

--- a/src/yencode/decoder.cc
+++ b/src/yencode/decoder.cc
@@ -21,6 +21,8 @@ void decoder_set_avx_funcs();
 
 void decoder_set_avx2_funcs();
 
+void decoder_set_vbmi2_funcs();
+
 void decoder_set_neon_funcs();
 
 
@@ -54,7 +56,9 @@ void decoder_init() {
     decoder_set_native_funcs();
 # else
     int use_isa = cpu_supports_isa();
-    if(use_isa >= ISA_LEVEL_AVX2) {
+    if(use_isa >= ISA_LEVEL_VBMI2) {
+        decoder_set_vbmi2_funcs();
+    } else if(use_isa >= ISA_LEVEL_AVX2) {
         decoder_set_avx2_funcs();
     } else if(use_isa >= ISA_LEVEL_AVX) {
         decoder_set_avx_funcs();
@@ -88,7 +92,7 @@ const char* simd_detected() {
         return "SSE4.1";
     if(_decode_simd_level >= ISA_LEVEL_SSSE3)
         return "SSSE3";
-    if(_decode_simd_level >= ISA_LEVEL_SSE2 | ISA_FEATURE_POPCNT | ISA_FEATURE_LZCNT)
+    if(_decode_simd_level >= (ISA_LEVEL_SSE2 | ISA_FEATURE_POPCNT | ISA_FEATURE_LZCNT))
         return "SSE2+ABM";
     return "SSE2";
 #endif

--- a/src/yencode/decoder.h
+++ b/src/yencode/decoder.h
@@ -38,6 +38,8 @@ extern YencDecoderEnd
 (*_do_decode_end_raw)(const unsigned char *HEDLEY_RESTRICT *, unsigned char *HEDLEY_RESTRICT *, size_t,
                       YencDecoderState *);
 
+extern int _decode_simd_level;
+
 static inline size_t
 do_decode(int isRaw, const unsigned char *HEDLEY_RESTRICT src, unsigned char *HEDLEY_RESTRICT dest, size_t len,
           YencDecoderState *state) {
@@ -53,6 +55,8 @@ do_decode_end(const unsigned char *HEDLEY_RESTRICT *src, unsigned char *HEDLEY_R
 }
 
 void decoder_init();
+
+const char* simd_detected();
 
 
 #ifdef __cplusplus

--- a/src/yencode/decoder_avx.cc
+++ b/src/yencode/decoder_avx.cc
@@ -9,6 +9,7 @@ void decoder_set_avx_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(__m128i)*2, do_decode_sse<false, false, ISA_LEVEL_SSE4_POPCNT> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(__m128i)*2, do_decode_sse<true, false, ISA_LEVEL_SSE4_POPCNT> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m128i)*2, do_decode_sse<true, true, ISA_LEVEL_SSE4_POPCNT> >;
+    _decode_simd_level = ISA_LEVEL_AVX;
 }
 #else
 

--- a/src/yencode/decoder_avx2.cc
+++ b/src/yencode/decoder_avx2.cc
@@ -9,6 +9,7 @@ void decoder_set_avx2_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(__m256i)*2, do_decode_avx2<false, false, ISA_LEVEL_AVX2> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(__m256i)*2, do_decode_avx2<true, false, ISA_LEVEL_AVX2> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m256i)*2, do_decode_avx2<true, true, ISA_LEVEL_AVX2> >;
+    _decode_simd_level = ISA_LEVEL_AVX2;
 }
 #else
 

--- a/src/yencode/decoder_avx2_base.h
+++ b/src/yencode/decoder_avx2_base.h
@@ -1,8 +1,8 @@
 
 #ifdef __AVX2__
 
-// GCC (ver 6-10(dev)) fails to optimize pure C version of mask testing, but has this intrinsic; Clang >= 7 optimizes C version fine
-#if defined(__GNUC__) && __GNUC__ >= 7
+// GCC (ver 6-10(dev)) fails to optimize pure C version of mask testing, but has this intrinsic; Clang >= 7 optimizes C version fine; functions added in Clang 8
+#if (defined(__GNUC__) && __GNUC__ >= 7) || (defined(_MSC_VER) && _MSC_VER >= 1924)
 # define KORTEST32(a, b) !_kortestz_mask32_u8((a), (b))
 # define KAND32(a, b) _kand_mask32((a), (b))
 # define KOR32(a, b) _kor_mask32((a), (b))
@@ -60,6 +60,15 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
             '.','.','.','.','.','.','.','.','.','.','.','.','.','.',_nextMask==2?0:'.',_nextMask==1?0:'.'
         );
     }
+	
+	// for some reason, MSVC Win32 seems to crash when trying to compile _mm256_mask_cmpeq_epi8_mask
+	// the crash can be fixed by switching the order of the last two arguments, but it seems to generate wrong code
+	// so just disable the optimisation as it seems to be problematic there
+#if defined(_MSC_VER) && !defined(PLATFORM_AMD64) && !defined(__clang__)
+	const bool useAVX3MaskCmp = false;
+#else
+	const bool useAVX3MaskCmp = (use_isa >= ISA_LEVEL_AVX3);
+#endif
     intptr_t i;
     for(i = -len; i; i += sizeof(__m256i)*2) {
         __m256i oDataA = _mm256_load_si256((__m256i *)(src+i));
@@ -126,7 +135,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
                 __mmask32 match2EqMaskA, match2EqMaskB;
                 __mmask32 match0CrMaskA, match0CrMaskB;
                 __mmask32 match2CrXDtMaskA, match2CrXDtMaskB;
-                if(use_isa >= ISA_LEVEL_AVX3 && searchEnd) {
+				if(useAVX3MaskCmp && searchEnd) {
                     match2EqMaskA = _mm256_cmpeq_epi8_mask(_mm256_set1_epi8('='), tmpData2A);
                     match2EqMaskB = _mm256_cmpeq_epi8_mask(_mm256_set1_epi8('='), tmpData2B);
                 } else
@@ -142,7 +151,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
                     // find patterns of \r_.
 
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match0CrMaskA = _mm256_cmpeq_epi8_mask(oDataA, _mm256_set1_epi8('\r'));
                         match0CrMaskB = _mm256_cmpeq_epi8_mask(oDataB, _mm256_set1_epi8('\r'));
                         match2CrXDtMaskA = _mm256_mask_cmpeq_epi8_mask(match0CrMaskA, tmpData2A, _mm256_set1_epi8('.'));
@@ -172,7 +181,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
                     __mmask32 match1NlMaskA, match1NlMaskB;
                     __mmask32 match2NlDotMaskA, match2NlDotMaskB;
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match1NlMaskA = _mm256_mask_cmpeq_epi8_mask(
                             match0CrMaskA,
                             _mm256_set1_epi8('\n'),
@@ -228,7 +237,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
 
                         int matchEnd;
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                        if(use_isa >= ISA_LEVEL_AVX3) {
+						if(useAVX3MaskCmp) {
                             __mmask32 match3EqYMaskA = _mm256_mask_cmpeq_epi8_mask(
                                 match2EqMaskA,
                                 _mm256_set1_epi8('y'),
@@ -307,7 +316,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
                         }
                     }
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         mask |= (uint64_t)match2NlDotMaskA << 2;
                         mask |= (uint64_t)match2NlDotMaskB << 34;
                         minMask = _mm256_maskz_mov_epi8(~(match2NlDotMaskB>>30), _mm256_set1_epi8('.'));
@@ -325,7 +334,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
                     __m256i match3EqYA, match3EqYB;
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
                     __mmask32 match3EqYMaskA, match3EqYMaskB;
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match3EqYMaskA = _mm256_mask_cmpeq_epi8_mask(
                             match2EqMaskA,
                             _mm256_set1_epi8('y'),
@@ -355,7 +364,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_avx2(const uint8_t* HEDLEY_RESTRICT src, lon
                     if(LIKELIHOOD(0.002, partialEndFound)) {
                         bool endFound;
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                        if(use_isa >= ISA_LEVEL_AVX3) {
+						if(useAVX3MaskCmp) {
                             __mmask32 match3LfEqYMaskA = _mm256_mask_cmpeq_epi8_mask(
                                 match3EqYMaskA,
                                 _mm256_set1_epi8('\n'),

--- a/src/yencode/decoder_neon.cc
+++ b/src/yencode/decoder_neon.cc
@@ -469,6 +469,7 @@ void decoder_set_neon_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(uint8x16_t)*2, do_decode_neon<false, false> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(uint8x16_t)*2, do_decode_neon<true, false> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(uint8x16_t)*2, do_decode_neon<true, true> >;
+    _decode_simd_level = 1;
 }
 #else
 

--- a/src/yencode/decoder_neon64.cc
+++ b/src/yencode/decoder_neon64.cc
@@ -448,6 +448,7 @@ void decoder_set_neon_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(uint8x16_t)*4, do_decode_neon<false, false> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(uint8x16_t)*4, do_decode_neon<true, false> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(uint8x16_t)*4, do_decode_neon<true, true> >;
+    _decode_simd_level = 1;
 }
 #else
 

--- a/src/yencode/decoder_sse2.cc
+++ b/src/yencode/decoder_sse2.cc
@@ -10,6 +10,7 @@ void decoder_set_sse2_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(__m128i)*2, do_decode_sse<false, false, ISA_LEVEL_SSE2> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(__m128i)*2, do_decode_sse<true, false, ISA_LEVEL_SSE2> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m128i)*2, do_decode_sse<true, true, ISA_LEVEL_SSE2> >;
+    _decode_simd_level = ISA_LEVEL_SSE2;
 }
 #else
 

--- a/src/yencode/decoder_sse_base.h
+++ b/src/yencode/decoder_sse_base.h
@@ -8,7 +8,7 @@
 #endif
 
 // GCC (ver 6-10(dev)) fails to optimize pure C version of mask testing, but has this intrinsic; Clang >= 7 optimizes C version fine
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if (defined(__GNUC__) && __GNUC__ >= 7) || (defined(_MSC_VER) && _MSC_VER >= 1924)
 # define KORTEST16(a, b) !_kortestz_mask16_u8((a), (b))
 # define KAND16(a, b) _kand_mask16((a), (b))
 # define KOR16(a, b) _kor_mask16((a), (b))
@@ -122,6 +122,11 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
 #else
     const bool _USING_BLEND_ADD = false;
 #endif
+#if defined(_MSC_VER) && !defined(PLATFORM_AMD64) && !defined(__clang__)
+	const bool useAVX3MaskCmp = false;
+#else
+	const bool useAVX3MaskCmp = (use_isa >= ISA_LEVEL_AVX3);
+#endif
 
     __m128i lfCompare = _mm_set1_epi8('\n');
     __m128i minMask = _mm_set1_epi8('.');
@@ -214,7 +219,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
                 __mmask16 match2EqMaskA, match2EqMaskB;
                 __mmask16 match0CrMaskA, match0CrMaskB;
                 __mmask16 match2CrXDtMaskA, match2CrXDtMaskB;
-                if(use_isa >= ISA_LEVEL_AVX3 && searchEnd) {
+				if(useAVX3MaskCmp && searchEnd) {
                     match2EqMaskA = _mm_cmpeq_epi8_mask(_mm_set1_epi8('='), tmpData2A);
                     match2EqMaskB = _mm_cmpeq_epi8_mask(_mm_set1_epi8('='), tmpData2B);
                 } else
@@ -230,7 +235,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
                 __m128i match2CrXDtA, match2CrXDtB;
                 if(isRaw) {
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match0CrMaskA = _mm_cmpeq_epi8_mask(oDataA, _mm_set1_epi8('\r'));
                         match0CrMaskB = _mm_cmpeq_epi8_mask(oDataB, _mm_set1_epi8('\r'));
                         match2CrXDtMaskA = _mm_mask_cmpeq_epi8_mask(match0CrMaskA, tmpData2A, _mm_set1_epi8('.'));
@@ -256,7 +261,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
                     __mmask16 match1NlMaskA, match1NlMaskB;
                     __mmask16 match2NlDotMaskA, match2NlDotMaskB;
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match1NlMaskA = _mm_mask_cmpeq_epi8_mask(
                             match0CrMaskA,
                             _mm_set1_epi8('\n'),
@@ -299,7 +304,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
 
                         int matchEnd;
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                        if(use_isa >= ISA_LEVEL_AVX3) {
+						if(useAVX3MaskCmp) {
                             __mmask16 match3EqYMaskA = _mm_mask_cmpeq_epi8_mask(
                                 match2EqMaskA, _mm_set1_epi8('y'), tmpData3A
                             );
@@ -373,7 +378,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
                         }
                     }
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         mask |= match2NlDotMaskA << 2;
                         mask |= (match2NlDotMaskB << 18) & 0xffffffff;
                         minMask = _mm_maskz_mov_epi8(~(match2NlDotMaskB>>14), _mm_set1_epi8('.'));
@@ -398,7 +403,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
                     __m128i match3EqYA, match3EqYB;
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
                     __mmask16 match3EqYMaskA, match3EqYMaskB;
-                    if(use_isa >= ISA_LEVEL_AVX3) {
+					if(useAVX3MaskCmp) {
                         match3EqYMaskA = _mm_mask_cmpeq_epi8_mask(
                             match2EqMaskA,
                             _mm_set1_epi8('y'),
@@ -434,7 +439,7 @@ HEDLEY_ALWAYS_INLINE void do_decode_sse(const uint8_t* HEDLEY_RESTRICT src, long
                         bool endFound;
 
 #if defined(__AVX512VL__) && defined(__AVX512BW__)
-                        if(use_isa >= ISA_LEVEL_AVX3) {
+						if(useAVX3MaskCmp) {
                             __mmask16 match3LfEqYMaskA = _mm_mask_cmpeq_epi8_mask(
                                 match3EqYMaskA,
                                 _mm_set1_epi8('\n'),

--- a/src/yencode/decoder_ssse3.cc
+++ b/src/yencode/decoder_ssse3.cc
@@ -9,6 +9,7 @@ void decoder_set_ssse3_funcs() {
     _do_decode = &do_decode_simd<false, false, sizeof(__m128i)*2, do_decode_sse<false, false, ISA_LEVEL_SSSE3> >;
     _do_decode_raw = &do_decode_simd<true, false, sizeof(__m128i)*2, do_decode_sse<true, false, ISA_LEVEL_SSSE3> >;
     _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m128i)*2, do_decode_sse<true, true, ISA_LEVEL_SSSE3> >;
+    _decode_simd_level = ISA_LEVEL_SSSE3;
 }
 #else
 

--- a/src/yencode/decoder_vbmi2.cc
+++ b/src/yencode/decoder_vbmi2.cc
@@ -1,0 +1,34 @@
+#include "common.h"
+
+#if defined(__AVX512VL__) && defined(__AVX512VBMI2__) && defined(__AVX512BW__)
+# include "decoder_common.h"
+# ifndef YENC_DISABLE_AVX256
+#  include "decoder_avx2_base.h"
+void decoder_set_vbmi2_funcs() {
+    ALIGN_ALLOC(lookups, sizeof(*lookups), 16);
+    // TODO: consider removing compact LUT
+    decoder_init_lut(lookups->eqFix, lookups->compact);
+    _do_decode = &do_decode_simd<false, false, sizeof(__m256i)*2, do_decode_avx2<false, false, ISA_LEVEL_VBMI2> >;
+    _do_decode_raw = &do_decode_simd<true, false, sizeof(__m256i)*2, do_decode_avx2<true, false, ISA_LEVEL_VBMI2> >;
+    _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m256i)*2, do_decode_avx2<true, true, ISA_LEVEL_VBMI2> >;
+    _decode_simd_level = ISA_LEVEL_VBMI2;
+}
+# else
+#  include "decoder_sse_base.h"
+void decoder_set_vbmi2_funcs() {
+    decoder_sse_init();
+    decoder_init_lut(lookups->eqFix, lookups->compact);
+    _do_decode = &do_decode_simd<false, false, sizeof(__m128i)*2, do_decode_sse<false, false, ISA_LEVEL_VBMI2> >;
+    _do_decode_raw = &do_decode_simd<true, false, sizeof(__m128i)*2, do_decode_sse<true, false, ISA_LEVEL_VBMI2> >;
+    _do_decode_end_raw = &do_decode_simd<true, true, sizeof(__m128i)*2, do_decode_sse<true, true, ISA_LEVEL_VBMI2> >;
+    _decode_simd_level = ISA_LEVEL_VBMI2;
+}
+# endif
+#else
+    
+void decoder_set_avx2_funcs();
+
+void decoder_set_vbmi2_funcs() {
+    decoder_set_avx2_funcs();
+}
+#endif

--- a/src/yencode/encoder.cc
+++ b/src/yencode/encoder.cc
@@ -134,6 +134,8 @@ void encoder_avx_init();
 
 void encoder_avx2_init();
 
+void encoder_vbmi2_init();
+
 void encoder_neon_init();
 
 #if defined(PLATFORM_X86) && defined(YENC_BUILD_NATIVE) && YENC_BUILD_NATIVE != 0
@@ -159,7 +161,9 @@ void encoder_init() {
     encoder_native_init();
 # else
     int use_isa = cpu_supports_isa();
-    if(use_isa >= ISA_LEVEL_AVX2) {
+    if(use_isa >= ISA_LEVEL_VBMI2) {
+        encoder_vbmi2_init();
+    } else if(use_isa >= ISA_LEVEL_AVX2) {
         encoder_avx2_init();
     } else if(use_isa >= ISA_LEVEL_AVX) {
         encoder_avx_init();

--- a/src/yencode/encoder_avx_base.h
+++ b/src/yencode/encoder_avx_base.h
@@ -7,7 +7,7 @@
 #include "encoder_common.h"
 #define YMM_SIZE 32
 
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if (defined(__GNUC__) && __GNUC__ >= 7) || (defined(_MSC_VER) && _MSC_VER >= 1924)
 # define KLOAD32(a, offs) _load_mask32((__mmask32*)(a) + (offs))
 #else
 # define KLOAD32(a, offs) (((uint32_t*)(a))[(offs)])

--- a/src/yencode/encoder_sse_base.h
+++ b/src/yencode/encoder_sse_base.h
@@ -8,7 +8,7 @@
 # define _mm_mask_expand_epi8 _mm128_mask_expand_epi8
 #endif
 
-#if defined(__GNUC__) && __GNUC__ >= 7
+#if (defined(__GNUC__) && __GNUC__ >= 7) || (defined(_MSC_VER) && _MSC_VER >= 1924)
 # define KLOAD16(a, offs) _load_mask16((__mmask16*)(a) + (offs))
 #else
 # define KLOAD16(a, offs) (((uint16_t*)(a))[(offs)])

--- a/src/yencode/encoder_vbmi2.cc
+++ b/src/yencode/encoder_vbmi2.cc
@@ -1,0 +1,25 @@
+#include "common.h"
+
+#if defined(__AVX512VL__) && defined(__AVX512VBMI2__) && defined(__AVX512BW__)
+# ifndef YENC_DISABLE_AVX256
+#  include "encoder_avx_base.h"
+
+void encoder_vbmi2_init() {
+    _do_encode = &do_encode_simd< do_encode_avx2<ISA_LEVEL_VBMI2> >;
+    encoder_avx2_lut<ISA_LEVEL_VBMI2>();
+}
+# else
+#  include "encoder_sse_base.h"
+void encoder_vbmi2_init() {
+    _do_encode = &do_encode_simd< do_encode_sse<ISA_LEVEL_VBMI2> >;
+    encoder_sse_lut<ISA_LEVEL_VBMI2>();
+}
+# endif
+#else
+
+void encoder_avx2_init();
+
+void encoder_vbmi2_init() {
+    encoder_avx2_init();
+}
+#endif

--- a/src/yencode/platform.cc
+++ b/src/yencode/platform.cc
@@ -167,24 +167,3 @@ int cpu_supports_crc_isa() {
 }
 
 #endif // PLATFORM_X86
-
-const char* simd_detected() {
-#ifdef PLATFORM_X86
-    int use_isa = cpu_supports_isa();
-    if(use_isa >= ISA_LEVEL_AVX2) {
-        return "AVX2";
-    } else if(use_isa >= ISA_LEVEL_AVX) {
-        return "AVX";
-    } else if(use_isa >= ISA_LEVEL_SSSE3) {
-        return "SSSE3";
-    } else {
-        return "SSE2";
-    }
-#endif
-#ifdef PLATFORM_ARM
-    if(cpu_supports_neon()) {
-        return "NEON";
-    }
-#endif
-    return "";
-}


### PR DESCRIPTION
This enables the VBMI2 ISA level already included in yencode. Support for the instruction set is currently limited, but I'm measuring around 15% improvement in decoder performance over AVX2.

This PR also changes the way `simd_detected` works to be more consistent with the actual function selection. Previously it would only check the CPU's capabilities, whereas now it'll also consider the compiler's capabilities.