### PR TITLE
import setuptools before distutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SABYenc 3 - yEnc decoding of usenet data using SIMD routines
 
 Modification of the original [yenc](https://pypi.org/project/yenc/) module for use within SABnzbd.
 The module was extended to do header parsing and full yEnc decoding from a Python
-list of chunks, the way in which data is retrieved from usenet.
+list of chunks, the way in which data is retrieved from Usenet.
 This is particularly beneficial when SSL is enabled, which limits the size of each chunk to 16K. Parsing these chunks in python is much more costly.
 Additionally, this module releases Python's GIL during decoding, greatly increasing performance of the overall download process.
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import sys
 import platform
 import re
 import tempfile
+from setuptools import distutils
 from distutils.ccompiler import CCompiler
 from distutils.errors import CompileError
 from typing import Type


### PR DESCRIPTION
Some recent change in setuptools caused build failure in the Debian package, reported there in bug [#1020033](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020033). This PR avoids the issue by importing setuptools prior to distutils, as suggested in the UserWarning:
```
I: pybuild base:240: /usr/bin/python3 setup.py build 
/<<PKGBUILDDIR>>/setup.py:29: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.ccompiler import CCompiler
/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:18: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
  warnings.warn(
/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
running build
running build_ext
==> Baseline detection: ARM=False, x86=True, macOS=False
==> Checking support for flag: -std=c++11
==> Please ignore any errors shown below!
creating tmp
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c /tmp/tmp_v5sbl5w.cc -o tmp/tmp_v5sbl5w.o -std=c++11
==> Success!
==> Checking support for define: __ILP32__
==> Please ignore any errors shown below!
x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.10 -c /tmp/tmp0h4oo8h4.cc -o tmp/tmp0h4oo8h4.o
/tmp/tmp0h4oo8h4.cc:2:2: error: #error __ILP32__ not available!
    2 | #error __ILP32__ not available!
      |  ^~~~~
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
E: pybuild pybuild:379: build: plugin distutils failed with: exit code=1: /usr/bin/python3 setup.py build 
```