### PR TITLE
Find the openssl handle via the python ssl module

### DIFF
--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -71,6 +71,9 @@ static struct PyModuleDef sabyenc3_definition = {
 static bool openssl_init() {
     // TODO: consider adding an extra version check to avoid possible future changes to SSL_read_ex
 
+    PyObject *ssl_module = PyImport_ImportModule("_ssl");
+    if(!ssl_module) return false;
+
 #if defined(_WIN32) || defined(__CYGWIN__)
     HMODULE openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
 
@@ -80,9 +83,6 @@ static bool openssl_init() {
     *(void**)&SSL_get_error = GetProcAddress(openssl_handle, "SSL_get_error");
 #else
     // Find library at "import ssl; print(ssl._ssl.__file__)"
-    PyObject *ssl_module = PyImport_ImportModule("_ssl");
-    if(!ssl_module) return false;
-
     PyObject *ssl_module_dict = PyModule_GetDict(ssl_module);
     if(!ssl_module_dict) return false;
 

--- a/tests/test_openssl_linked.py
+++ b/tests/test_openssl_linked.py
@@ -1,0 +1,5 @@
+from tests.testsupport import *
+
+
+def test_openssl_linked():
+    assert sabyenc3.openssl_linked == True


### PR DESCRIPTION
I had a look at making the linking more robust and work for more exotic Python installs such as homebrew.

Related to #76, you said you didn't try this method because the symbols don't get re-exported, I don't really understand how it works but the required dependencies are being loaded and the functions are available.

I've tested and called the method on Linux and Mac (python.org and homebrew).

I also added a test :)

Because it imports `_ssl` itself you don't have to ensure "import ssl" comes first and those lines could move up to also apply to the Windows version.
I think we need the loaded module to stay loaded to keep the handle valid, therefore I don't call `Py_XDECREF(ssl_module)`.

---

Also [SSL_read_ex](https://www.openssl.org/docs/man1.1.1/man3/SSL_read_ex.html) was added in OpenSSL 1.1.1 so if you don't want to do this method then a few of the libraries it tries could be removed since they'll never have SSL_read_ex.
