### PR TITLE
Refactor openssl_link for stability, safety and better error state handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -288,7 +288,8 @@ class SAByEncBuild(build_ext):
                 "sources": [
                     "src/unlocked_ssl.cc",
                 ],
-                "gcc_flags": ["-Wno-unused-parameter"],
+                "gcc_flags": ["-Wno-unused-parameter", "-Wno-missing-field-initializers"],
+                'msvc_x86_libraries': ['ws2_32'],
             },
         ]:
             args = {
@@ -300,6 +301,8 @@ class SAByEncBuild(build_ext):
             if self.compiler.compiler_type == "msvc":
                 if IS_X86 and "msvc_x86_flags" in source_files:
                     args["extra_postargs"] += source_files["msvc_x86_flags"]
+                if IS_X86 and "msvc_x86_libraries" in source_files:
+                    ext.libraries += source_files["msvc_x86_libraries"]
             else:
                 if "gcc_flags" in source_files:
                     args["extra_postargs"] += source_files["gcc_flags"]

--- a/setup.py
+++ b/setup.py
@@ -284,6 +284,12 @@ class SAByEncBuild(build_ext):
                 "include_dirs": ["src/crcutil-1.0/code", "src/crcutil-1.0/tests"],
                 "macros": [("CRCUTIL_USE_MM_CRC32", "0")],
             },
+            {
+                "sources": [
+                    "src/unlocked_ssl.cc",
+                ],
+                "gcc_flags": ["-Wno-unused-parameter"],
+            },
         ]:
             args = {
                 "sources": source_files["sources"],
@@ -312,7 +318,7 @@ class SAByEncBuild(build_ext):
 
         # attach to Extension
         ext.extra_link_args = ldflags + compiled_objects
-        ext.depends = ["src/sabyenc3.h"] + compiled_objects
+        ext.depends = ["src/sabyenc3.h", "src/unlocked_ssl.h"] + compiled_objects
 
         # proceed with regular Extension build
         super(SAByEncBuild, self).build_extension(ext)

--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -35,7 +35,6 @@ static size_t decode_buffer_usenet(PyObject *, char *, int, char **, uint32_t *)
 static char * find_text_in_pylist(PyObject *, const char *, char **, int *);
 int extract_filename_from_pylist(PyObject *, int *, char **, char **, char **);
 uLong extract_int_from_pylist(PyObject *, int *, char **, char **);
-PyObject *SSLWantReadError;
 
 /* Python API requirements */
 static PyMethodDef sabyenc3_methods[] = {
@@ -85,9 +84,6 @@ PyMODINIT_FUNC PyInit_sabyenc3(void) {
     Py_INCREF(openssl_linked_object);
     PyModule_AddObject(m, "openssl_linked", openssl_linked_object);
 
-    // Add our own exception
-    SSLWantReadError = PyErr_NewException("sabyenc3.SSLWantReadError", NULL, NULL);
-    PyModule_AddObject(m, "SSLWantReadError", SSLWantReadError);
     return m;
 }
 

--- a/src/sabyenc3.h
+++ b/src/sabyenc3.h
@@ -46,30 +46,7 @@ typedef int Bool;
 #define strtoll _strtoi64
 #endif
 
-/* Limited sub-struct of Python struct */
-typedef struct {
-    PyObject_HEAD
-    PyObject *Socket; /* We do not use it, but needs to match Python */
-    void *ssl;
-} PySSLSocket;
-
-/* OpenSSL link */
-#if defined(_WIN32) || defined(__CYGWIN__)
-# define SABYENC_DLL_CALL __stdcall
-# define WIN32_LEAN_AND_MEAN
-# include <Windows.h>
-#else
-# define SABYENC_DLL_CALL
-# include <dlfcn.h>
-#endif
-int (SABYENC_DLL_CALL *SSL_read_ex)(void*, void*, size_t, size_t*) = NULL;
-int (SABYENC_DLL_CALL *SSL_get_error)(void*, int) = NULL;
-
-/* Have to manually define this OpenSSL constant and hope it never changes */
-# define SSL_ERROR_WANT_READ 2
-
 /* Functions */
 PyObject* decode_usenet_chunks(PyObject *, PyObject*);
 PyObject* encode(PyObject *, PyObject*);
-PyObject* unlocked_ssl_recv_into(PyObject *, PyObject*);
 PyMODINIT_FUNC PyInit_sabyenc3(void);

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -2,6 +2,90 @@
 
 int (SABYENC_DLL_CALL *SSL_read_ex)(void*, void*, size_t, size_t*);
 int (SABYENC_DLL_CALL *SSL_get_error)(void*, int);
+int (SABYENC_DLL_CALL *SSL_get_shutdown)(void*);
+
+/* Redefined below for Windows debug builds after important #includes */
+#define _PySSL_FIX_ERRNO
+
+#define PySSL_BEGIN_ALLOW_THREADS_S(save) \
+    do { (save) = PyEval_SaveThread(); } while(0)
+#define PySSL_END_ALLOW_THREADS_S(save) \
+    do { PyEval_RestoreThread(save); _PySSL_FIX_ERRNO; } while(0)
+#define PySSL_BEGIN_ALLOW_THREADS { \
+            PyThreadState *_save = NULL;  \
+            PySSL_BEGIN_ALLOW_THREADS_S(_save);
+#define PySSL_END_ALLOW_THREADS PySSL_END_ALLOW_THREADS_S(_save); }
+
+typedef struct {
+    int ssl; /* last seen error from SSL */
+    int c; /* last seen error from libc */
+#ifdef MS_WINDOWS
+    int ws; /* last seen error from winsock */
+#endif
+} _PySSLError;
+
+typedef struct {
+    PyObject_HEAD
+            PyObject *Socket; /* weakref to socket on which we're layered */
+    void *ssl;
+    void *ctx; /* weakref to SSL context */
+    char shutdown_seen_zero;
+    int socket_type;
+    PyObject *owner; /* Python level "owner" passed to servername callback */
+    PyObject *server_hostname;
+    _PySSLError err; /* last seen error from various sources */
+    /* Some SSL callbacks don't have error reporting. Callback wrappers
+     * store exception information on the socket. The handshake, read, write,
+     * and shutdown methods check for chained exceptions.
+     */
+    PyObject *exc_type;
+    PyObject *exc_value;
+    PyObject *exc_tb;
+} PySSLSocket;
+
+static inline _PySSLError _PySSL_errno(int failed, void *ssl, int retcode)
+{
+    _PySSLError err = { 0 };
+    if (failed) {
+#ifdef MS_WINDOWS
+        err.ws = WSAGetLastError();
+        _PySSL_FIX_ERRNO;
+#endif
+        err.c = errno;
+        err.ssl = SSL_get_error(ssl, retcode);
+    }
+    return err;
+}
+
+/* The object holding a socket.  It holds some extra information,
+   like the address family, which is used to decode socket address
+   arguments properly. */
+
+typedef struct {
+    PyObject_HEAD
+            SOCKET_T sock_fd;           /* Socket file descriptor */
+    int sock_family;            /* Address family, e.g., AF_INET */
+    int sock_type;              /* Socket type, e.g., SOCK_STREAM */
+    int sock_proto;             /* Protocol type, usually 0 */
+    PyObject *(*errorhandler)(void); /* Error handler; checks
+                                        errno, returns NULL and
+                                        sets a Python exception */
+    _PyTime_t sock_timeout;     /* Operation timeout in seconds;
+                                        0.0 means non-blocking */
+} PySocketSockObject;
+
+typedef enum {
+    SOCKET_IS_NONBLOCKING,
+    SOCKET_IS_BLOCKING,
+    SOCKET_HAS_TIMED_OUT,
+    SOCKET_HAS_BEEN_CLOSED,
+    SOCKET_TOO_LARGE_FOR_SELECT,
+    SOCKET_OPERATION_OK
+} timeout_state;
+
+/* Get the socket from a PySSLSocket, if it has one */
+#define GET_SOCKET(obj) ((obj)->Socket ? \
+    (PySocketSockObject *) PyWeakref_GetObject((obj)->Socket) : NULL)
 
 /* Linking to OpenSSL function used by Python */
 void openssl_init() {
@@ -17,6 +101,7 @@ void openssl_init() {
     if(!openssl_handle) return;
     *(void**)&SSL_read_ex = GetProcAddress(openssl_handle, "SSL_read_ex");
     *(void**)&SSL_get_error = GetProcAddress(openssl_handle, "SSL_get_error");
+    *(void**)&SSL_get_shutdown = GetProcAddress(openssl_handle, "SSL_get_shutdown");
 #else
     // Find library at "import ssl; print(ssl._ssl.__file__)"
     PyObject *ssl_module_dict = PyModule_GetDict(ssl_module);
@@ -31,24 +116,130 @@ void openssl_init() {
 
     *(void**)&SSL_read_ex = dlsym(openssl_handle, "SSL_read_ex");
     *(void**)&SSL_get_error = dlsym(openssl_handle, "SSL_get_error");
-    if(!SSL_read_ex || !SSL_get_error) dlclose(openssl_handle);
+    *(void**)&SSL_get_shutdown = dlsym(openssl_handle, "SSL_get_shutdown");
+
+    if (!openssl_linked()) dlclose(openssl_handle);
 #endif
 }
 
 bool openssl_linked() {
-    return SSL_read_ex && SSL_get_error;
+    return SSL_read_ex && SSL_get_error && SSL_get_shutdown;
 }
 
-PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
-    PySSLSocket *Py_ssl_socket;
-    Py_buffer Py_buffer;
-    size_t nbytes;
+static int PySSL_ChainExceptions(PySSLSocket *sslsock) {
+    if (sslsock->exc_type == NULL)
+        return 0;
+
+    _PyErr_ChainExceptions(sslsock->exc_type, sslsock->exc_value, sslsock->exc_tb);
+    sslsock->exc_type = NULL;
+    sslsock->exc_value = NULL;
+    sslsock->exc_tb = NULL;
+    return -1;
+}
+
+static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, Py_buffer *buffer) {
     char *mem;
     size_t count = 0;
     size_t readbytes = 0;
     int retval;
-    int err;
-    PyObject *Py_retval = NULL;
+    int sockstate;
+    _PySSLError err;
+    PySocketSockObject *sock = GET_SOCKET(self);
+
+    mem = (char *)buffer->buf;
+    if (len <= 0 || len > buffer->len) {
+        len = (int) buffer->len;
+        if (buffer->len != len) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "maximum length can't fit in a C 'int'");
+            goto error;
+        }
+        if (len == 0) {
+            count = 0;
+            goto done;
+        }
+    }
+
+    if (sock != NULL) {
+        if (((PyObject*)sock) == Py_None) {
+            // TODO: likely need this exception
+//            _setSSLError(get_state_sock(self),
+//                         "Underlying socket connection gone",
+//                         PY_SSL_ERROR_NO_SOCKET, __FILE__, __LINE__);  // TODO:
+            PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
+            return NULL;
+        }
+        Py_INCREF(sock);
+    }
+
+    do {
+        PySSL_BEGIN_ALLOW_THREADS;
+        do {
+            retval = SSL_read_ex(self->ssl, mem + count, len, &readbytes);
+            if (retval <= 0) {
+                break;
+            }
+            count += readbytes;
+            len -= readbytes;
+        } while (len > 0);
+        err = _PySSL_errno(retval == 0, self->ssl, retval);
+        PySSL_END_ALLOW_THREADS;
+        self->err = err;
+
+        if (count > 0) {
+            break;
+        }
+
+        if (PyErr_CheckSignals())
+            goto error;
+
+        if (err.ssl == SSL_ERROR_WANT_READ) {
+            sockstate = SOCKET_IS_NONBLOCKING;
+        } else if (err.ssl == SSL_ERROR_WANT_WRITE) {
+            sockstate = SOCKET_IS_NONBLOCKING;
+        } else if (err.ssl == SSL_ERROR_ZERO_RETURN &&
+                SSL_get_shutdown(self->ssl) == SSL_RECEIVED_SHUTDOWN)
+        {
+            count = 0;
+            goto done;
+        }
+        else
+            sockstate = SOCKET_OPERATION_OK;
+
+        if (sockstate == SOCKET_IS_NONBLOCKING) {
+            break;
+        }
+    } while (err.ssl == SSL_ERROR_WANT_READ ||
+             err.ssl == SSL_ERROR_WANT_WRITE);
+
+    if (count == 0) {
+//        PySSL_SetError(self, retval, __FILE__, __LINE__); // TODO:
+        if (err.ssl == SSL_ERROR_WANT_READ) {
+            PyErr_SetString(SSLWantReadError, "Need more data");
+        } else {
+            // Raise general error, since we don't care
+            PyErr_SetString(PyExc_ValueError, "Failed to read data");
+        }
+        goto error;
+    }
+    if (self->exc_type != NULL)
+        goto error;
+
+    done:
+    Py_XDECREF(sock);
+    return PyLong_FromSize_t(count);
+
+    error:
+    PySSL_ChainExceptions(self);
+    Py_XDECREF(sock);
+    return NULL;
+}
+
+PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
+    PySSLSocket *Py_ssl_socket;
+    Py_ssize_t len;
+    Py_buffer Py_buffer;
+    PyObject *retval;
 
     if(!openssl_linked()) {
         PyErr_SetString(PyExc_OSError, "Failed to link with OpenSSL");
@@ -56,46 +247,27 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     }
 
     // Parse input
-    if (!PyArg_ParseTuple(args, "Ow*:unlocked_ssl_recv", &Py_ssl_socket, &Py_buffer)) {
+    if (!PyArg_ParseTuple(args, "Ow*:unlocked_ssl_recv_into", &Py_ssl_socket, &Py_buffer)) {
         return NULL;
     }
 
     // Basic sanity check
-    nbytes = (size_t)Py_buffer.len;
-    if (nbytes <= 0) {
+    len = (Py_ssize_t)Py_buffer.len;
+    if (len <= 0) {
         PyErr_SetString(PyExc_ValueError, "No space left in buffer");
-        goto finish;
-    }
-    mem = (char *)Py_buffer.buf;
-
-    Py_BEGIN_ALLOW_THREADS;
-    do {
-        retval = SSL_read_ex(Py_ssl_socket->ssl, mem + count, nbytes, &readbytes);
-        if (retval <= 0) {
-            break;
-        }
-        count += readbytes;
-        nbytes -= readbytes;
-    } while (nbytes > 0);
-    Py_END_ALLOW_THREADS;
-
-    // Check for errors if no data was recieved
-    if (count == 0 && retval == 0) {
-        err = SSL_get_error(Py_ssl_socket->ssl, retval);
-        if (err == SSL_ERROR_WANT_READ) {
-            PyErr_SetString(SSLWantReadError, "Need more data");
-        } else {
-            // Raise general error, since we don't care
-            PyErr_SetString(PyExc_ValueError, "Failed to read data");
-        }
-        goto finish;
+        goto error;
     }
 
-    // All good, return number of bytes fetched
-    Py_retval = PyLong_FromSize_t(count);
+    retval = unlocked_ssl_recv_into_impl(Py_ssl_socket, len, &Py_buffer);
+    if (!retval) {
+        goto error;
+    }
 
-    finish:
-    // Release buffer
+    done:
     PyBuffer_Release(&Py_buffer);
-    return Py_retval;
+    return retval;
+
+    error:
+    PyBuffer_Release(&Py_buffer);
+    return NULL;
 }

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -227,5 +227,6 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
 
     error:
     PyBuffer_Release(&Py_buffer);
+    Py_XDECREF(Py_ssl_socket);
     return retval;
 }

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -15,9 +15,9 @@ typedef struct {
 
 typedef struct {
     PyObject_HEAD
-            PyObject *Socket; /* weakref to socket on which we're layered */
+    PyObject *Socket; /* weakref to socket on which we're layered */
     void *ssl;
-    void *ctx; /* weakref to SSL context */
+    PyObject *ctx; /* weakref to SSL context */
     char shutdown_seen_zero;
     int socket_type;
     PyObject *owner; /* Python level "owner" passed to servername callback */

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -57,23 +57,6 @@ static inline _PySSLError _PySSL_errno(int failed, void *ssl, int retcode)
     return err;
 }
 
-/* The object holding a socket.  It holds some extra information,
-   like the address family, which is used to decode socket address
-   arguments properly. */
-
-typedef struct {
-    PyObject_HEAD
-            SOCKET_T sock_fd;           /* Socket file descriptor */
-    int sock_family;            /* Address family, e.g., AF_INET */
-    int sock_type;              /* Socket type, e.g., SOCK_STREAM */
-    int sock_proto;             /* Protocol type, usually 0 */
-    PyObject *(*errorhandler)(void); /* Error handler; checks
-                                        errno, returns NULL and
-                                        sets a Python exception */
-    _PyTime_t sock_timeout;     /* Operation timeout in seconds;
-                                        0.0 means non-blocking */
-} PySocketSockObject;
-
 typedef enum {
     SOCKET_IS_NONBLOCKING,
     SOCKET_IS_BLOCKING,
@@ -85,7 +68,7 @@ typedef enum {
 
 /* Get the socket from a PySSLSocket, if it has one */
 #define GET_SOCKET(obj) ((obj)->Socket ? \
-    (PySocketSockObject *) PyWeakref_GetObject((obj)->Socket) : NULL)
+    (PyObject *) PyWeakref_GetObject((obj)->Socket) : NULL)
 
 /* Linking to OpenSSL function used by Python */
 void openssl_init() {
@@ -144,7 +127,7 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
     int retval;
     int sockstate;
     _PySSLError err;
-    PySocketSockObject *sock = GET_SOCKET(self);
+    PyObject *sock = GET_SOCKET(self);
 
     mem = (char *)buffer->buf;
     if (len <= 0 || len > buffer->len) {

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -1,0 +1,101 @@
+#include "unlocked_ssl.h"
+
+int (SABYENC_DLL_CALL *SSL_read_ex)(void*, void*, size_t, size_t*);
+int (SABYENC_DLL_CALL *SSL_get_error)(void*, int);
+
+/* Linking to OpenSSL function used by Python */
+void openssl_init() {
+    // TODO: consider adding an extra version check to avoid possible future changes to SSL_read_ex
+
+    PyObject *ssl_module = PyImport_ImportModule("_ssl");
+    if(!ssl_module) return;
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    HMODULE openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
+
+    // TODO: more DLL names?
+    if(!openssl_handle) return;
+    *(void**)&SSL_read_ex = GetProcAddress(openssl_handle, "SSL_read_ex");
+    *(void**)&SSL_get_error = GetProcAddress(openssl_handle, "SSL_get_error");
+#else
+    // Find library at "import ssl; print(ssl._ssl.__file__)"
+    PyObject *ssl_module_dict = PyModule_GetDict(ssl_module);
+    if(!ssl_module_dict) return;
+
+    PyObject *ssl_module_path = PyDict_GetItemString(ssl_module_dict, "__file__");
+    if(!ssl_module_path) return;
+
+    void* openssl_handle = dlopen(PyUnicode_AsUTF8(ssl_module_path), RTLD_LAZY | RTLD_NOLOAD);
+
+    if(!openssl_handle) return;
+
+    *(void**)&SSL_read_ex = dlsym(openssl_handle, "SSL_read_ex");
+    *(void**)&SSL_get_error = dlsym(openssl_handle, "SSL_get_error");
+    if(!SSL_read_ex || !SSL_get_error) dlclose(openssl_handle);
+#endif
+}
+
+bool openssl_linked() {
+    return SSL_read_ex && SSL_get_error;
+}
+
+PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
+    PySSLSocket *Py_ssl_socket;
+    Py_buffer Py_buffer;
+    size_t nbytes;
+    char *mem;
+    size_t count = 0;
+    size_t readbytes = 0;
+    int retval;
+    int err;
+    PyObject *Py_retval = NULL;
+
+    if(!openssl_linked()) {
+        PyErr_SetString(PyExc_OSError, "Failed to link with OpenSSL");
+        return NULL;
+    }
+
+    // Parse input
+    if (!PyArg_ParseTuple(args, "Ow*:unlocked_ssl_recv", &Py_ssl_socket, &Py_buffer)) {
+        return NULL;
+    }
+
+    // Basic sanity check
+    nbytes = (size_t)Py_buffer.len;
+    if (nbytes <= 0) {
+        PyErr_SetString(PyExc_ValueError, "No space left in buffer");
+        goto finish;
+    }
+    mem = (char *)Py_buffer.buf;
+
+    Py_BEGIN_ALLOW_THREADS;
+    do {
+        retval = SSL_read_ex(Py_ssl_socket->ssl, mem + count, nbytes, &readbytes);
+        if (retval <= 0) {
+            break;
+        }
+        count += readbytes;
+        nbytes -= readbytes;
+    } while (nbytes > 0);
+    Py_END_ALLOW_THREADS;
+
+    // Check for errors if no data was recieved
+    if (count == 0 && retval == 0) {
+        err = SSL_get_error(Py_ssl_socket->ssl, retval);
+        if (err == SSL_ERROR_WANT_READ) {
+            PyErr_SetString(SSLWantReadError, "Need more data");
+        } else {
+            // Raise general error, since we don't care
+            PyErr_SetString(PyExc_ValueError, "Failed to read data");
+        }
+        goto finish;
+    }
+
+    // All good, return number of bytes fetched
+    Py_retval = PyLong_FromSize_t(count);
+
+    finish:
+    // Release buffer
+    PyBuffer_Release(&Py_buffer);
+    return Py_retval;
+}

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -76,12 +76,12 @@ void openssl_init() {
 #if defined(_WIN32) || defined(__CYGWIN__)
     // TODO: more DLL names?
 
-    HMODULE openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
-    if(!openssl_handle) goto cleanup;
+    HMODULE windows_openssl_handle = GetModuleHandle(TEXT("libssl-1_1.dll"));
+    if(!windows_openssl_handle) goto cleanup;
 
-    *(void**)&SSL_read_ex = GetProcAddress(openssl_handle, "SSL_read_ex");
-    *(void**)&SSL_get_error = GetProcAddress(openssl_handle, "SSL_get_error");
-    *(void**)&SSL_get_shutdown = GetProcAddress(openssl_handle, "SSL_get_shutdown");
+    *(void**)&SSL_read_ex = GetProcAddress(windows_openssl_handle, "SSL_read_ex");
+    *(void**)&SSL_get_error = GetProcAddress(windows_openssl_handle, "SSL_get_error");
+    *(void**)&SSL_get_shutdown = GetProcAddress(windows_openssl_handle, "SSL_get_shutdown");
 #else
     // Find library at "import ssl; print(ssl._ssl.__file__)"
 

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -226,6 +226,7 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
 }
 
 PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
+    PyObject *ssl_socket;
     PySSLSocket *Py_ssl_socket;
     Py_ssize_t len;
     Py_buffer Py_buffer;
@@ -237,8 +238,14 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     }
 
     // Parse input
-    if (!PyArg_ParseTuple(args, "Ow*:unlocked_ssl_recv_into", &Py_ssl_socket, &Py_buffer)) {
+    if (!PyArg_ParseTuple(args, "Ow*:unlocked_ssl_recv_into", &ssl_socket, &Py_buffer)) {
         return NULL;
+    }
+
+    Py_ssl_socket = (PySSLSocket*)PyObject_GetAttrString(ssl_socket, "_sslobj");
+    if (Py_ssl_socket == NULL) {
+        PyErr_SetString(PyExc_ValueError, "Not an SSLSocket");
+        goto error;
     }
 
     // Basic sanity check

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -224,7 +224,7 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     PySSLSocket *Py_ssl_socket;
     Py_ssize_t len;
     Py_buffer Py_buffer;
-    PyObject *retval;
+    PyObject *retval = NULL;
 
     if(!openssl_linked()) {
         PyErr_SetString(PyExc_OSError, "Failed to link with OpenSSL");
@@ -250,15 +250,8 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     }
 
     retval = unlocked_ssl_recv_into_impl(Py_ssl_socket, len, &Py_buffer);
-    if (!retval) {
-        goto error;
-    }
-
-    done:
-    PyBuffer_Release(&Py_buffer);
-    return retval;
 
     error:
     PyBuffer_Release(&Py_buffer);
-    return NULL;
+    return retval;
 }

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -1,0 +1,45 @@
+#ifndef SABYENC_UNLOCKED_SSL_RECV_INTO_H
+#define SABYENC_UNLOCKED_SSL_RECV_INTO_H
+
+#include <Python.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <string.h>
+
+/* OpenSSL link */
+#if defined(_WIN32) || defined(__CYGWIN__)
+# define SABYENC_DLL_CALL __stdcall
+# define WIN32_LEAN_AND_MEAN
+# include <Windows.h>
+#else
+# define SABYENC_DLL_CALL
+# include <dlfcn.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//typedef int (SABYENC_DLL_CALL *ssl_read_ex_func)(const void *, size_t, uint32_t);
+//int (SABYENC_DLL_CALL *SSL_read_ex)(void*, void*, size_t, size_t*);
+
+/* Limited sub-struct of Python struct */
+typedef struct {
+    PyObject_HEAD
+            PyObject *Socket; /* We do not use it, but needs to match Python */
+    void *ssl;
+} PySSLSocket;
+
+/* Have to manually define this OpenSSL constant and hope it never changes */
+# define SSL_ERROR_WANT_READ 2
+
+extern PyObject *SSLWantReadError;
+
+void openssl_init();
+bool openssl_linked();
+PyObject *unlocked_ssl_recv_into(PyObject *, PyObject*);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -58,8 +58,6 @@ typedef int SOCKET_T;
 #       define SIZEOF_SOCKET_T SIZEOF_INT
 #endif
 
-extern PyObject *SSLWantReadError;
-
 void openssl_init();
 bool openssl_linked();
 PyObject *unlocked_ssl_recv_into(PyObject *, PyObject*);

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -1,5 +1,5 @@
-#ifndef SABYENC_UNLOCKED_SSL_RECV_INTO_H
-#define SABYENC_UNLOCKED_SSL_RECV_INTO_H
+#ifndef SABYENC_UNLOCKED_SSL_H
+#define SABYENC_UNLOCKED_SSL_H
 
 #include <Python.h>
 #include <stdio.h>
@@ -20,18 +20,43 @@
 extern "C" {
 #endif
 
-//typedef int (SABYENC_DLL_CALL *ssl_read_ex_func)(const void *, size_t, uint32_t);
-//int (SABYENC_DLL_CALL *SSL_read_ex)(void*, void*, size_t, size_t*);
-
-/* Limited sub-struct of Python struct */
-typedef struct {
-    PyObject_HEAD
-            PyObject *Socket; /* We do not use it, but needs to match Python */
-    void *ssl;
-} PySSLSocket;
-
 /* Have to manually define this OpenSSL constant and hope it never changes */
+# define SSL_RECEIVED_SHUTDOWN 2
 # define SSL_ERROR_WANT_READ 2
+# define SSL_ERROR_WANT_WRITE 3
+# define SSL_ERROR_ZERO_RETURN 6
+
+#ifndef MS_WINDOWS
+#ifdef __VMS
+#   include <socket.h>
+# else
+#   include <sys/socket.h>
+# endif
+# include <netinet/in.h>
+# include <netinet/tcp.h>
+
+#else /* MS_WINDOWS */
+# include <winsock2.h>
+
+#ifdef MS_WINDOWS
+#  define WIN32_LEAN_AND_MEAN
+#  include <winsock.h>
+#else
+#  define SOCKET int
+#endif
+#endif
+
+#ifdef MS_WINDOWS
+typedef SOCKET SOCKET_T;
+#       ifdef MS_WIN64
+#               define SIZEOF_SOCKET_T 8
+#       else
+#               define SIZEOF_SOCKET_T 4
+#       endif
+#else
+typedef int SOCKET_T;
+#       define SIZEOF_SOCKET_T SIZEOF_INT
+#endif
 
 extern PyObject *SSLWantReadError;
 

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -11,6 +11,7 @@
 # define SABYENC_DLL_CALL __stdcall
 # define WIN32_LEAN_AND_MEAN
 # include <Windows.h>
+# include <winsock2.h>
 #else
 # define SABYENC_DLL_CALL
 # include <dlfcn.h>
@@ -25,38 +26,6 @@ extern "C" {
 # define SSL_ERROR_WANT_READ 2
 # define SSL_ERROR_WANT_WRITE 3
 # define SSL_ERROR_ZERO_RETURN 6
-
-#ifndef MS_WINDOWS
-#ifdef __VMS
-#   include <socket.h>
-# else
-#   include <sys/socket.h>
-# endif
-# include <netinet/in.h>
-# include <netinet/tcp.h>
-
-#else /* MS_WINDOWS */
-# include <winsock2.h>
-
-#ifdef MS_WINDOWS
-#  define WIN32_LEAN_AND_MEAN
-#  include <winsock.h>
-#else
-#  define SOCKET int
-#endif
-#endif
-
-#ifdef MS_WINDOWS
-typedef SOCKET SOCKET_T;
-#       ifdef MS_WIN64
-#               define SIZEOF_SOCKET_T 8
-#       else
-#               define SIZEOF_SOCKET_T 4
-#       endif
-#else
-typedef int SOCKET_T;
-#       define SIZEOF_SOCKET_T SIZEOF_INT
-#endif
 
 void openssl_init();
 bool openssl_linked();

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
 pytest
 chardet
+jaraco.functools
+portend

--- a/tests/test_openssl_linked.py
+++ b/tests/test_openssl_linked.py
@@ -1,5 +1,0 @@
-from tests.testsupport import *
-
-
-def test_openssl_linked():
-    assert sabyenc3.openssl_linked == True

--- a/tests/test_unlocked_ssl.py
+++ b/tests/test_unlocked_ssl.py
@@ -1,0 +1,244 @@
+import os
+import socket
+import ssl
+import sys
+import tempfile
+import threading
+
+import pytest
+import portend
+
+from tests.testsupport import *
+
+HOST = "127.0.0.1"
+
+cert = """-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIUXYYp1atAnSypLyKprYna65kFn9owDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMzAxMTAwODE5NDVaFw0zMzAx
+MDcwODE5NDVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQDWHsTQOLJ0O/WdJ2pr/IjwXEcrFr6xiDuxQGwJQxkI
+beY4w/jFxz9TmRwkIm+wrqw6o/4BxRJIJrot0byaJzSYlYJS+ChH1rRa3E72Jb0L
+Kfk1peNcTInujHStXv93aLbxhamswg2M7gTUPelZeIlTHf/YsLzx4KEfF/PSs6DJ
+eOUHmGcFE01Ypef0tM+72DncrRbDWKbAC5IQm2g4yCC/L6RYNbpOn5Cm9/M1JPnx
++Gn6ylrWQhquVrLnxEfupNgCWiRTZXSvy6jNPgGEi92OiwT5M3MMn/FZVxDKILHg
+B9esr1b3s6qTW3sclcLXKIC1eG1/ikUmVfbVonmnlLuHao6SfHWeV7kuBdqnYQFN
+UgZ11xtakWC/dwjIt101MjFe3PlgLfgxeSMXZFYpBc0RwBfmBavEHbbRTgebloIO
+xrPMIvbFiNg9osoC8nTKwtrEMo0MlCYyElXs18hLzo3GvL1bCUCQiqj4sRBFKG4B
+SgyhV/i72kuf9FhdcM4IJFoCc9B2Ll9KCflhhwGe+f/1cpd6nlKXgI2+UfgHY0Nj
+UqDqq7gLg0WMCpSKasH68e4UDzceUUB1d7OwJwljxJxGuZErKIQbGi0wKVy0evRO
+lcb5IL9l8rPfxE1aqlQ6VbDJ91rOrYdB6MugWNK3KfYPcAXHkPsWcMPtO4R2nEeR
+FwIDAQABo1MwUTAdBgNVHQ4EFgQUp9LcqyRllH3ZN/WpSPjxVybPSZowHwYDVR0j
+BBgwFoAUp9LcqyRllH3ZN/WpSPjxVybPSZowDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAgEAaeyercYN95kMCdLCjX9jmAGhG6WB3eFvEwmTtcSoxo3Q
+6/LBk8EdikfirIHuJKZVxTRuvRA/KniDI/pJC16qcRUI0OmQFtCirqD7kiR/fkYO
+IXqh3wzu4bBGewf+MLGtJjYxn83w/KP7kj3ZTaoOLbmizBDWCMlYdYwbqTVfuOCL
+hQwvRpiqeOBNCphvrreo6HqLaiWaRPb60NZqEu+yI7ltGN+QDKQJ04CJT1gLqkAB
+MsmvLLmQDPtnhE16zqZc5iZ3FHFm+sSSQq5jImjmCHT8aNGk4ng0VuQQsMZClgmx
+U6SvMo2u5akK9h3d9L2QT9vc8Zn/gUdQW4N1kLBU2HoHod/KLKkPrWGR4oIowYmk
+C/nQjh/qxJFk6zEwo7Woo2+mQop9vKnA5jH24qbuCm0k4GfJegB7FCaW7TcRTwxy
+wExvMNVgaZ3+Fuf/dbGTG3EHSfQO+hPMFCvo7WQ+ndQcqEmLlyNnV9owfHOYYo1l
+TgLUi49uVqHLfN3BZPIOVW3FP26OLxdVRQf1OdwR5+eDp6CXceO5U7kZJN5L7ZMi
+fDIh4KerzRZrtdt6Y/CnxI6R1qDHfpK2BA8DJpyhhDUap7OrGhktqb1nTT0hrLAq
+acN1EC6NLepwbQL0RR3Xhmu3Jq59bXRVpjCMHC4rQHQvbG01vT0SjENM38RGUbk=
+-----END CERTIFICATE-----
+"""
+
+key = """-----BEGIN PRIVATE KEY-----
+MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQDWHsTQOLJ0O/Wd
+J2pr/IjwXEcrFr6xiDuxQGwJQxkIbeY4w/jFxz9TmRwkIm+wrqw6o/4BxRJIJrot
+0byaJzSYlYJS+ChH1rRa3E72Jb0LKfk1peNcTInujHStXv93aLbxhamswg2M7gTU
+PelZeIlTHf/YsLzx4KEfF/PSs6DJeOUHmGcFE01Ypef0tM+72DncrRbDWKbAC5IQ
+m2g4yCC/L6RYNbpOn5Cm9/M1JPnx+Gn6ylrWQhquVrLnxEfupNgCWiRTZXSvy6jN
+PgGEi92OiwT5M3MMn/FZVxDKILHgB9esr1b3s6qTW3sclcLXKIC1eG1/ikUmVfbV
+onmnlLuHao6SfHWeV7kuBdqnYQFNUgZ11xtakWC/dwjIt101MjFe3PlgLfgxeSMX
+ZFYpBc0RwBfmBavEHbbRTgebloIOxrPMIvbFiNg9osoC8nTKwtrEMo0MlCYyElXs
+18hLzo3GvL1bCUCQiqj4sRBFKG4BSgyhV/i72kuf9FhdcM4IJFoCc9B2Ll9KCflh
+hwGe+f/1cpd6nlKXgI2+UfgHY0NjUqDqq7gLg0WMCpSKasH68e4UDzceUUB1d7Ow
+JwljxJxGuZErKIQbGi0wKVy0evROlcb5IL9l8rPfxE1aqlQ6VbDJ91rOrYdB6Mug
+WNK3KfYPcAXHkPsWcMPtO4R2nEeRFwIDAQABAoICAAFhYGZxPyFFs68oLmT001Mt
+XR4XfvI5DR1261th7drijn3mMYfg4XUiAw7uk+bBMYYNQZl0UkpZyZB7Diq2Pv4O
+1LDBPc08wpvlWLL4ik/0nNEuORmCus7pY+UsPBxide93q6Db/Wdfr3NI1OTJRKVf
+B6O3e/hZOOCw8Fb25n32BA/4+Q0M005Tf3vR4Jb27WSRTxjCTQzm5jGqNtFK5P8m
+iPoymnlgSPfymERK8TuQnOpLfKtt8KsYDv40gzw0HtphB2PsPwTVHMj58duPZUXC
+eq06mi7GJzGqwIZ1EIB/vHG2Dar6IwrhJ5mHE6L8dVv2I0qTsx9spXM6IWulp1HU
+pM5Ix+teQGkoIUOl+/mbjMNbQbY0FSAnpckOkeGzzBv1i+mGg6q1w6twnFeseHgG
+OTHPwdHDM2j++jKTMbwWVEbHqlOorstPYDyvgcs2en7k/ty/I+RGiuotQ9Wsb9oA
+kkC351dVb3vgCEUJOhTA+3AOujNmSpAj7/f8y27iT2UHCh57KJovO9ovfNkKihEE
+IAbfYZLPcfDf/PPF5BLpsRHYLopLKrlRnkIXXUE8/9gQ1ze4AHHciWIvIWzEsP5c
+fGicLOYEZETAcJ2ymciTSLkwRpmtSf/sHV3HHepc/zQh0HbbD4+atvGOGu5kBQMm
+AcfNTew3VOVJQcFYdHaVAoIBAQDaKmWpOwHUIVO2M/PL4L+/0jQ1M/pHNKiFT4uH
+EmIvLimuiLrNEB7BWkzcidrOmP4LaMKuRVGTH1womE6agvCOyR3gm8rKzyVqEsPT
+tj5PhSxdRHONN6+jWIMd3SX+MsUndT/mjEJmr8nEOXICUMkQG8CAoHZldhSJkbsz
+po04wvFtlLjtJpkpdVfbpN9zvpNFzc6Vr8hm6rAnYpYGjghQqFAzxlnan/sSCMO9
+qSS6Sre1KnHwz8CB264hERVuONQIxpilFXVXA3Q5ebdru+mWy2nLLEd21/tcB4HL
+js+BAFkLgAmtXitEq9r39bXaXUibVyPSc146Aq56ir+DIDJbAoIBAQD7QMXEQrNv
+bcwMI6ed1pNP7z0TeNIGHDEi1s4XLxcRqzHBJmCmxgF9sG5C2vpozWCKcLUYAKQ2
+3tYpQYW0Afogq+bynNP1M9DsV3lxdurPASUEY7ef14kjcBnwcbLT+csY6gNo9GN7
+o4+PIyEC5mVULqhkEGSqewBb3WazDZ7TL0AF13KPCAJ44bNsU6RTmJobMK3oQIjN
+cS0ccwzf+3U0RdX/vUwKy3HcoI2lUDdQIL8BHGQjv9yovmz1i01brtpQlwLcMaLc
+Iq3f6PbedJOcVxHo8MMOr9XLxXU0/0tgUAWpwE8icgBbsB5rLBRtWHKYvUwjR3rc
+tVu+1GOoRCD1AoIBACpM3CdC5KjfyV5jllqqeiNUO4ExUc6qnB40/SW0X8ssFTLd
+GfMWtA/jVVHRfNZf/anypwSpNhbjlrfcSClXSBM3VY6uRlSqc2OsvcF37X73oFF5
+KzpvWKPATrPkpDA0YduztS8bdOh6HxHn3X4rccCo0NtfwXUMvxCpa/Wozmr6CVuo
+4W5B9KKAOQfCYP0NL3ryW6LUUXP6/yqzx8j/kwcoi1xukg98w26Mun80o4VnZVVA
+JJV/gqDrGkkZCeG0LRCCiShBD95OMiPOwMynw7PUPvAA5t5ZJEiEwBra1sr5aUp8
+iePOhW8sLymyv47WVXShIbX1Xoi66l+iNV3USU8CggEAQ7Y7Fh9buEYA3aymOZVg
+cgRpk1vWTis+2sLFG95m+y4F5KXxGkD2meb4cDAPmDrxL54cT/GsT9VSJiAwZki6
+Hh/1x6CYRtbGEUupwPhpY4xNa5dsHzm5DcHiW7hol1QUdgxrCtgCD4oO4GZ5OQza
+dgt0+jKozoEDob5TNSIQkZ2ERY7AoudnsygwcJtCB/1yWq2N0K/Droo3vBkNeTeN
+aJ8Bg0CCw838S5dBVTH/FisdDrGWE0RbtWZMewgluvWuhFWOQcVmvKjj7xobnewQ
+8+tLOlnYV5bvqVD3u2ap67TlMdBQA1px2kPmjr98adOSXrN1V3SmGeEObqlSikCC
+GQKCAQBjDOzM3L8+R2QNvj/ZEU6rwYnb3/Rx+F+O1L386J4WtLurClvzXtL91Q5u
+T9UunYOYRsx1rYBSaQdPVOR7K0hU1N9kEOBNeDTQQ/qqH8voX4TrARETCDyB/Fls
+4HC+IWzrQV9HIZqn8ruT7hSiDnB4R7g5m6k39+G+avAUWZKdCaOZiCUml/SkGuL6
+kKjT522r8NfZH+bk/Y0WCIF8+Fd4EtqCSpPUZnTqm0j52mSF994N2MhW+/McpqMh
+mNAV+BDsdh9VeyHZgK9d/1jhy2MKNLbuJndQ3/rkjPUKnDhbeI4UvsL10cBcYS+q
+ZNWqBl74DpmsArY6Tz4P6sbK+jVl
+-----END PRIVATE KEY-----
+"""
+
+
+class EchoServer(threading.Thread):
+    """An SSL echo server"""
+    def __init__(self, host=HOST):
+        super().__init__()
+        self.host = host
+        self.port = portend.find_available_local_port()
+        self.should_stop = threading.Event()
+        self.running = threading.Event()
+
+    def run(self) -> None:
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                certfile = tmp.name
+                with open(certfile, 'w') as f:
+                    f.write(cert)
+                    f.close()
+
+            with tempfile.NamedTemporaryFile(delete=False) as tmp:
+                keyfile = tmp.name
+                with open(keyfile, 'w') as f:
+                    f.write(key)
+                    f.close()
+
+            server_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            server_context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+            server_context.set_ciphers("HIGH")
+
+            server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server_socket.settimeout(0.2)
+            server_socket.bind((self.host, self.port))
+            server_socket.listen()
+
+            try:
+                with server_context.wrap_socket(sock=server_socket, server_side=True) as ssock:
+                    self.running.set()
+                    ssock.settimeout(1)
+                    while not self.should_stop.is_set():
+                        try:
+                            conn, addr = ssock.accept()
+                            data = conn.read()
+                            if not data:
+                                continue
+                            conn.sendall(data)
+                            conn.close()
+                        except socket.timeout:
+                            pass
+            finally:
+                server_socket.close()
+                self.running.clear()
+        finally:
+            os.unlink(certfile)
+            os.unlink(keyfile)
+
+
+@pytest.fixture(scope='module')
+def server():
+    server = EchoServer()
+    server.start()
+    if server.running.wait(2.0):
+        yield server
+    else:
+        raise ValueError("EchoServer is not ready for connections within timeout")
+    server.should_stop.set()
+
+
+def unlocked_ssl_recv_into_wrapper(sock: ssl.SSLSocket, data: bytes, data_view: memoryview) -> int:
+    """Send data to the socket and writes the response to a buffer"""
+    sock.sendall(data)
+    data_position = 0
+    while True:
+        try:
+            data_position += sabyenc3.unlocked_ssl_recv_into(sock, data_view[data_position:])
+        except ssl.SSLWantReadError:
+            pass
+        if data_position > 0:
+            break
+    return data_position
+
+
+@pytest.fixture()
+def client(server):
+    with socket.create_connection((server.host, server.port)) as sock:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        context.check_hostname = False
+        context.verify_mode = ssl.VerifyMode.CERT_NONE
+        with context.wrap_socket(sock, server_hostname=server.host) as ssock:
+            ssock.setblocking(False)
+            yield ssock
+
+
+@pytest.fixture()
+def buffer():
+    yield memoryview(bytearray(1024))
+
+
+def test_openssl_linked():
+    assert sabyenc3.openssl_linked is True
+
+
+def test_unlocked_ssl_recv_into_not_a_socket_fails(buffer):
+    with pytest.raises(TypeError, match=r"argument 1 must be SSLSocket"):
+        sabyenc3.unlocked_ssl_recv_into("this is not a socket", buffer)
+
+
+def test_unlocked_ssl_recv_into_not_a_buffer_fails(client):
+    with pytest.raises(TypeError, match=r"argument 2 must be read-write bytes-like object"):
+        unlocked_ssl_recv_into_wrapper(client, b"TEST", "...")
+
+
+def test_unlocked_ssl_recv_into_response(client, buffer):
+    bytes_received = unlocked_ssl_recv_into_wrapper(client, b"TEST", buffer)
+    assert buffer[:bytes_received].tobytes() == b"TEST"
+
+
+#
+def test_unlocked_ssl_recv_into_blocking_socket_fails(client, buffer):
+    with pytest.raises(ValueError, match="Only non-blocking sockets are supported"):
+        client.setblocking(True)
+        unlocked_ssl_recv_into_wrapper(client, b"TEST", buffer)
+
+
+def test_unlocked_ssl_recv_into_full_buffer_fails(client, buffer):
+    with pytest.raises(ValueError, match="No space left in buffer"):
+        unlocked_ssl_recv_into_wrapper(client, b"TEST", buffer[len(buffer):])
+
+
+def test_unlocked_ssl_recv_into_ref_counts_unchanged(client, buffer):
+    objects = [
+        client,
+        client._sslobj,
+        buffer,
+    ]
+
+    before = [sys.getrefcount(x) for x in objects]
+
+    bytes_received = unlocked_ssl_recv_into_wrapper(client, b"Hello World", buffer)
+    assert buffer[:bytes_received].tobytes() == b"Hello World"
+
+    after = [sys.getrefcount(x) for x in objects]
+
+    assert after == before

--- a/tests/test_unlocked_ssl.py
+++ b/tests/test_unlocked_ssl.py
@@ -207,7 +207,7 @@ class EchoServer(threading.Thread):
         while self.active:
             try:
                 conn, addr = self.sock.accept()
-                handler = self.ConnectionHandler(self, conn, addr, 65536)
+                handler = self.ConnectionHandler(self, conn, addr, 131072)
                 handler.start()
                 handler.join()
             except TimeoutError:
@@ -285,10 +285,10 @@ def test_unlocked_ssl_recv_into_response(client, buffer):
 
 
 def test_unlocked_ssl_recv_into_bulk_response(client):
-    # 65536 bytes divide up into 4 TLS records (16 KB each)
-    # In nonblocking mode, we should be able to read all four in a single
+    # 131072 bytes divide up into 8 TLS records (16 KB each)
+    # In nonblocking mode, we should be able to read all eight in a single
     # drop of the GIL.
-    size = 65536
+    size = 131072
     buffer = bytearray(size)
 
     client.sendall(b'\xFF' * size)
@@ -301,7 +301,7 @@ def test_unlocked_ssl_recv_into_bulk_response(client):
         except ssl.SSLWantReadError:
             select.select([client], [], [])
             # Give the sender some more time to complete sending.
-            time.sleep(0.01)
+            time.sleep(0.1)
         else:
             if count > 16384:
                 return


### PR DESCRIPTION
I've split the core code into two methods:

## unlocked_ssl_recv_into_impl
Stays as close to the cpython implementation of `_ssl__SSLSocket_read_impl` as possible to make it simpler to merge in any of their changes.

The main change is including error state hanlding and avoids uses of discarded sockets.

Stips out much of the code that we wouldn't hit:
- Removed option to return bytes, only reads to a buffer
- Decoration of exceptions - I didn't spend too long figuring out what this code does but I think it may be related to the stacktraces and chaining of them
 - You'll get a ssl.SSLWantReadError or generic PyExc_ValueError on failure - the same as previous implementation but hooks the exception from ssl
- Does not support sockets other than non-blocking - the timeout and poll of sock state are not handled

## unlocked_ssl_recv_into
This is the method exposed by the extension, I've changed it to take a `SSLSocket` instead of `PySSLSocket` (`sock` not `sock._sslobj`) - it's neater and the method checks that `_sslobj` exists.

# Miscellaneous
- Moved it into it's own files - easier to manage and seperate the cpython code
- Gets SSLWantReadError from the ssl/_ssl module
- Added a few more macros for SSL_* - they haven't changed in >24 years so I think this is OK - we could get most of them from the ssl module but it's not worth it
- openssl_init() doesn't return anything anymore but added a `bool openssl_linked()` method
- openssl_init() simpler failure handling, hooks a few more things and added missing ref counting

I think that's everything 💥 I'll leave you to add something about license and attributing the cpython code.