### PR TITLE
Add crc32 method utility methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,6 +291,13 @@ class SAByEncBuild(build_ext):
                 "gcc_flags": ["-Wno-unused-parameter", "-Wno-missing-field-initializers"],
                 'msvc_x86_libraries': ['ws2_32'],
             },
+            {
+                "sources": [
+                    "src/crc32.cc",
+                ],
+                "gcc_flags": ["-Wno-unused-parameter"],
+                "include_dirs": ["src/crcutil-1.0/code", "src/crcutil-1.0/examples"],
+            },
         ]:
             args = {
                 "sources": source_files["sources"],

--- a/src/crc32.cc
+++ b/src/crc32.cc
@@ -42,7 +42,7 @@ PyObject* crc32_zero_unpad(PyObject *self, PyObject *args) {
 }
 
 PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLongMask(arg);
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLong(arg);
 
     if (PyErr_Occurred()) {
         return NULL;
@@ -50,11 +50,11 @@ PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
 
     crc->XpowN(&n);
 
-    return PyLong_FromUnsignedLongLong(n);
+    return PyLong_FromUnsignedLong(n);
 }
 
 PyObject* crc32_xpow8n(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLongMask(arg);
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLong(arg);
 
     if (PyErr_Occurred()) {
         return NULL;
@@ -62,5 +62,5 @@ PyObject* crc32_xpow8n(PyObject* self, PyObject* arg) {
 
     crc->Xpow8N(&n);
 
-    return PyLong_FromUnsignedLongLong(n);
+    return PyLong_FromUnsignedLong(n);
 }

--- a/src/crc32.cc
+++ b/src/crc32.cc
@@ -42,7 +42,7 @@ PyObject* crc32_zero_unpad(PyObject *self, PyObject *args) {
 }
 
 PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLong(arg);
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) & 0xffffffff;
 
     if (PyErr_Occurred()) {
         return NULL;
@@ -54,7 +54,7 @@ PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
 }
 
 PyObject* crc32_xpow8n(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLong(arg);
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) & 0xffffffff;
 
     if (PyErr_Occurred()) {
         return NULL;

--- a/src/crc32.cc
+++ b/src/crc32.cc
@@ -1,0 +1,69 @@
+#include "crc32.h"
+#include "crcutil-1.0/examples/interface.h"
+
+extern crcutil_interface::CRC *crc;
+
+PyObject* crc32_combine(PyObject *self, PyObject *args) {
+    uint32_t crc1, crc2;
+    size_t length;
+
+    if(!PyArg_ParseTuple(args, "IIn:crc32_combine", &crc1, &crc2, &length)) {
+        return NULL;
+    }
+
+    crcutil_interface::UINT64 crc1_ = crc1, crc2_ = crc2;
+    crc->Concatenate(crc2_, 0, length, &crc1_);
+
+    return PyLong_FromUnsignedLong((uint32_t) crc1_);
+}
+
+PyObject* crc32_multiply(PyObject *self, PyObject *args) {
+    uint32_t crc1, crc2;
+
+    if(!PyArg_ParseTuple(args, "II:crc32_multiply", &crc1, &crc2)) {
+        return NULL;
+    }
+
+    crcutil_interface::UINT64 crc1_ = crc1, crc2_ = crc2;
+    crc->Multiply(crc2_, &crc1_);
+
+    return PyLong_FromUnsignedLong((uint32_t) crc1_);
+}
+
+PyObject* crc32_zero_unpad(PyObject *self, PyObject *args) {
+    uint32_t crc1;
+    size_t length;
+
+    if(!PyArg_ParseTuple(args, "In:crc32_zero_unpad", &crc1, &length)) {
+        return NULL;
+    }
+
+    crcutil_interface::UINT64 crc_ = crc1;
+    crc->ZeroUnpad(length, &crc_);
+
+    return PyLong_FromUnsignedLong((uint32_t) crc_);
+}
+
+PyObject* crc32_XpowN(PyObject* self, PyObject* arg) {
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg);
+
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    crc->XpowN(&n);
+
+    return PyLong_FromUnsignedLongLong(n);
+}
+
+PyObject* crc32_Xpow8N(PyObject* self, PyObject* arg) {
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg);
+
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    crc->Xpow8N(&n);
+
+    return PyLong_FromUnsignedLongLong(n);
+}

--- a/src/crc32.cc
+++ b/src/crc32.cc
@@ -4,48 +4,45 @@
 extern crcutil_interface::CRC *crc;
 
 PyObject* crc32_combine(PyObject *self, PyObject *args) {
-    uint32_t crc1, crc2;
-    size_t length;
+    crcutil_interface::UINT64 crc1, crc2;
+    Py_ssize_t length;
 
-    if(!PyArg_ParseTuple(args, "IIn:crc32_combine", &crc1, &crc2, &length)) {
+    if(!PyArg_ParseTuple(args, "KKn:crc32_combine", &crc1, &crc2, &length)) {
         return NULL;
     }
 
-    crcutil_interface::UINT64 crc1_ = crc1, crc2_ = crc2;
-    crc->Concatenate(crc2_, 0, length, &crc1_);
+    crc->Concatenate(crc2, 0, length, &crc1);
 
-    return PyLong_FromUnsignedLong((uint32_t) crc1_);
+    return PyLong_FromUnsignedLong((uint32_t) crc1);
 }
 
 PyObject* crc32_multiply(PyObject *self, PyObject *args) {
-    uint32_t crc1, crc2;
+    crcutil_interface::UINT64 crc1, crc2;
 
-    if(!PyArg_ParseTuple(args, "II:crc32_multiply", &crc1, &crc2)) {
+    if(!PyArg_ParseTuple(args, "KK:crc32_multiply", &crc1, &crc2)) {
         return NULL;
     }
 
-    crcutil_interface::UINT64 crc1_ = crc1, crc2_ = crc2;
-    crc->Multiply(crc2_, &crc1_);
+    crc->Multiply(crc2, &crc1);
 
-    return PyLong_FromUnsignedLong((uint32_t) crc1_);
+    return PyLong_FromUnsignedLong((uint32_t)crc1);
 }
 
 PyObject* crc32_zero_unpad(PyObject *self, PyObject *args) {
-    uint32_t crc1;
-    size_t length;
+    crcutil_interface::UINT64 crc1;
+    Py_ssize_t length;
 
-    if(!PyArg_ParseTuple(args, "In:crc32_zero_unpad", &crc1, &length)) {
+    if(!PyArg_ParseTuple(args, "Kn:crc32_zero_unpad", &crc1, &length)) {
         return NULL;
     }
 
-    crcutil_interface::UINT64 crc_ = crc1;
-    crc->ZeroUnpad(length, &crc_);
+    crc->ZeroUnpad(length, &crc1);
 
-    return PyLong_FromUnsignedLong((uint32_t) crc_);
+    return PyLong_FromUnsignedLong((uint32_t) crc1);
 }
 
-PyObject* crc32_XpowN(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg);
+PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLongMask(arg);
 
     if (PyErr_Occurred()) {
         return NULL;
@@ -56,8 +53,8 @@ PyObject* crc32_XpowN(PyObject* self, PyObject* arg) {
     return PyLong_FromUnsignedLongLong(n);
 }
 
-PyObject* crc32_Xpow8N(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg);
+PyObject* crc32_xpow8n(PyObject* self, PyObject* arg) {
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLongMask(arg);
 
     if (PyErr_Occurred()) {
         return NULL;

--- a/src/crc32.cc
+++ b/src/crc32.cc
@@ -42,7 +42,7 @@ PyObject* crc32_zero_unpad(PyObject *self, PyObject *args) {
 }
 
 PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) & 0xffffffff;
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) % 0xffffffff;
 
     if (PyErr_Occurred()) {
         return NULL;
@@ -54,7 +54,7 @@ PyObject* crc32_xpown(PyObject* self, PyObject* arg) {
 }
 
 PyObject* crc32_xpow8n(PyObject* self, PyObject* arg) {
-    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) & 0xffffffff;
+    crcutil_interface::UINT64 n = PyLong_AsUnsignedLongLong(arg) % 0xffffffff;
 
     if (PyErr_Occurred()) {
         return NULL;

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -1,0 +1,12 @@
+#ifndef SABYENC_CRC32_H
+#define SABYENC_CRC32_H
+
+#include <Python.h>
+
+PyObject* crc32_combine(PyObject *, PyObject*);
+PyObject* crc32_multiply(PyObject *, PyObject*);
+PyObject* crc32_zero_unpad(PyObject *, PyObject*);
+PyObject* crc32_XpowN(PyObject *, PyObject*);
+PyObject* crc32_Xpow8N(PyObject *, PyObject*);
+
+#endif //SABYENC_CRC32_H

--- a/src/crc32.h
+++ b/src/crc32.h
@@ -6,7 +6,7 @@
 PyObject* crc32_combine(PyObject *, PyObject*);
 PyObject* crc32_multiply(PyObject *, PyObject*);
 PyObject* crc32_zero_unpad(PyObject *, PyObject*);
-PyObject* crc32_XpowN(PyObject *, PyObject*);
-PyObject* crc32_Xpow8N(PyObject *, PyObject*);
+PyObject* crc32_xpown(PyObject *, PyObject*);
+PyObject* crc32_xpow8n(PyObject *, PyObject*);
 
 #endif //SABYENC_CRC32_H

--- a/src/crcutil-1.0/examples/interface.cc
+++ b/src/crcutil-1.0/examples/interface.cc
@@ -160,6 +160,30 @@ template<typename CrcImplementation, typename RollingCrcImplementation>
              crcA_hi);
   }
 
+  virtual void Multiply(UINT64 crcA_lo,
+                        /* INOUT */ UINT64* crcB_lo = NULL) const {
+    SetValue(crc_.Base().Multiply(GetValue(crcA_lo, 0),
+                                  GetValue(crcB_lo, 0)),
+             crcB_lo,
+             NULL);
+  }
+
+  virtual void ZeroUnpad(UINT64 bytes,
+                         /* INOUT */ UINT64 *lo) const {
+    SetValue(crc_.Base().Multiply(GetValue(lo, NULL) ^ crc_.Base().Canonize(),
+                                  crc_.Base().Xpow8N(bytes ^ 0xFFFFFFFF)) ^ crc_.Base().Canonize(),
+             lo,
+             NULL);
+  }
+
+  virtual void XpowN(/* INOUT */UINT64 *n) const {
+      SetValue(crc_.Base().XpowN(*n), n, NULL);
+  }
+
+  virtual void Xpow8N(/* INOUT */UINT64 *n) const {
+      SetValue(crc_.Base().Xpow8N(*n), n, NULL);
+  }
+
   virtual size_t StoreComplementaryCrc(
       void *dst,
       UINT64 message_crc_lo, UINT64 message_crc_hi,

--- a/src/crcutil-1.0/examples/interface.h
+++ b/src/crcutil-1.0/examples/interface.h
@@ -151,6 +151,16 @@ class CRC {
                            /* INOUT */ UINT64* crcA_lo,
                            /* INOUT */ UINT64* crcA_hi = NULL) const = 0;
 
+  virtual void Multiply(UINT64 crcA_lo,
+                        /* INOUT */ UINT64* crcB_lo = NULL) const = 0;
+
+  virtual void ZeroUnpad(UINT64 bytes,
+                         /* INOUT */ UINT64 *lo) const = 0;
+
+  virtual void XpowN(/* INOUT */ UINT64 *n) const = 0;
+
+  virtual void Xpow8N(/* INOUT */ UINT64 *n) const = 0;
+
   // Given CRC of a message, stores extra (degree + 7)/8 bytes after
   // the message so that CRC(message+extra, start) = result.
   // Does not change CRC start value (use ChangeStartValue for that).

--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -82,16 +82,16 @@ static PyMethodDef sabyenc3_methods[] = {
         "crc32_zero_unpad(crc1, length)"
     },
     {
-        "crc32_XpowN",
-        crc32_XpowN,
+        "crc32_xpown",
+        crc32_xpown,
         METH_O,
-        "crc32_XpowN(n)"
+        "crc32_xpown(n)"
     },
     {
-        "crc32_Xpow8N",
-        crc32_Xpow8N,
+        "crc32_xpow8n",
+        crc32_xpow8n,
         METH_O,
-        "crc32_Xpow8N(n)"
+        "crc32_xpow8n(n)"
     },
     {NULL, NULL, 0, NULL}
 };

--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -64,8 +64,8 @@ static PyMethodDef sabyenc3_methods[] = {
     },
     {
         "crc32_combine",
-        (PyCFunction)crc32_combine,
-        METH_FASTCALL,
+        crc32_combine,
+        METH_VARARGS,
         "crc32_combine(crc1, crc2, length)"
     },
     {NULL, NULL, 0, NULL}
@@ -786,11 +786,11 @@ PyObject* encode(PyObject* self, PyObject* Py_input_string)
     return retval;
 }
 
-PyObject* crc32_combine(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+PyObject* crc32_combine(PyObject *self, PyObject *args) {
     uint32_t crc1, crc2;
     size_t length;
 
-    if(!_PyArg_ParseStack(args, nargs, "IIn:crc32_combine", &crc1, &crc2, &length)) {
+    if(!PyArg_ParseTuple(args, "IIn:crc32_combine", &crc1, &crc2, &length)) {
         return NULL;
     }
 

--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -62,6 +62,12 @@ static PyMethodDef sabyenc3_methods[] = {
         METH_VARARGS,
         "unlocked_ssl_recv_into(ssl_socket, buffer)"
     },
+    {
+        "crc32_combine",
+        (PyCFunction)crc32_combine,
+        METH_FASTCALL,
+        "crc32_combine(crc1, crc2, length)"
+    },
     {NULL, NULL, 0, NULL}
 };
 
@@ -778,4 +784,15 @@ PyObject* encode(PyObject* self, PyObject* Py_input_string)
     Py_XDECREF(Py_output_string);
     free(output_buffer);
     return retval;
+}
+
+PyObject* crc32_combine(PyObject *self, PyObject *const *args, Py_ssize_t nargs) {
+    uint32_t crc1, crc2;
+    size_t length;
+
+    if(!_PyArg_ParseStack(args, nargs, "IIn:crc32_combine", &crc1, &crc2, &length)) {
+        return NULL;
+    }
+
+    return PyLong_FromUnsignedLong(do_crc32_combine(crc1, crc2, length));
 }

--- a/src/sabyenc3.cc
+++ b/src/sabyenc3.cc
@@ -21,6 +21,7 @@
 
 #include "sabyenc3.h"
 #include "unlocked_ssl.h"
+#include "crc32.h"
 
 #include "yencode/common.h"
 #include "yencode/encoder.h"
@@ -67,6 +68,30 @@ static PyMethodDef sabyenc3_methods[] = {
         crc32_combine,
         METH_VARARGS,
         "crc32_combine(crc1, crc2, length)"
+    },
+    {
+        "crc32_multiply",
+        crc32_multiply,
+        METH_VARARGS,
+        "crc32_multiply(crc1, crc2)"
+    },
+    {
+        "crc32_zero_unpad",
+        crc32_zero_unpad,
+        METH_VARARGS,
+        "crc32_zero_unpad(crc1, length)"
+    },
+    {
+        "crc32_XpowN",
+        crc32_XpowN,
+        METH_O,
+        "crc32_XpowN(n)"
+    },
+    {
+        "crc32_Xpow8N",
+        crc32_Xpow8N,
+        METH_O,
+        "crc32_Xpow8N(n)"
     },
     {NULL, NULL, 0, NULL}
 };
@@ -784,15 +809,4 @@ PyObject* encode(PyObject* self, PyObject* Py_input_string)
     Py_XDECREF(Py_output_string);
     free(output_buffer);
     return retval;
-}
-
-PyObject* crc32_combine(PyObject *self, PyObject *args) {
-    uint32_t crc1, crc2;
-    size_t length;
-
-    if(!PyArg_ParseTuple(args, "IIn:crc32_combine", &crc1, &crc2, &length)) {
-        return NULL;
-    }
-
-    return PyLong_FromUnsignedLong(do_crc32_combine(crc1, crc2, length));
 }

--- a/src/sabyenc3.h
+++ b/src/sabyenc3.h
@@ -50,5 +50,4 @@ typedef int Bool;
 PyObject* decode_usenet_chunks(PyObject *, PyObject*);
 PyObject* decode_buffer(PyObject *, PyObject*);
 PyObject* encode(PyObject *, PyObject*);
-PyObject* crc32_combine(PyObject *, PyObject*);
 PyMODINIT_FUNC PyInit_sabyenc3(void);

--- a/src/sabyenc3.h
+++ b/src/sabyenc3.h
@@ -50,4 +50,5 @@ typedef int Bool;
 PyObject* decode_usenet_chunks(PyObject *, PyObject*);
 PyObject* decode_buffer(PyObject *, PyObject*);
 PyObject* encode(PyObject *, PyObject*);
+PyObject* crc32_combine(PyObject *, PyObject * const*, Py_ssize_t);
 PyMODINIT_FUNC PyInit_sabyenc3(void);

--- a/src/sabyenc3.h
+++ b/src/sabyenc3.h
@@ -50,5 +50,5 @@ typedef int Bool;
 PyObject* decode_usenet_chunks(PyObject *, PyObject*);
 PyObject* decode_buffer(PyObject *, PyObject*);
 PyObject* encode(PyObject *, PyObject*);
-PyObject* crc32_combine(PyObject *, PyObject * const*, Py_ssize_t);
+PyObject* crc32_combine(PyObject *, PyObject*);
 PyMODINIT_FUNC PyInit_sabyenc3(void);

--- a/tests/test_crc32.py
+++ b/tests/test_crc32.py
@@ -56,22 +56,11 @@ def test_crc32_zero_unpad_expected(crc1, zeroes, expected):
         (30, 2),
         (31, 1),
         (4294967295, 2147483648),
+        (4294967296, 2147483648),  # 0
     ],
 )
 def test_crc32_xpown_expected(n, expected):
     assert sabyenc3.crc32_xpown(n) == expected
-
-
-@pytest.mark.parametrize(
-    "n",
-    [
-        -1,
-        4294967296,
-    ],
-)
-def test_crc32_xpown_out_of_range(n):
-    with pytest.raises(OverflowError):
-        sabyenc3.crc32_xpown(n)
 
 
 @pytest.mark.parametrize(
@@ -80,19 +69,8 @@ def test_crc32_xpown_out_of_range(n):
         (0, 2147483648),
         (1, 8388608),
         (4294967295, 2147483648),
+        (4294967296, 2147483648),  # 0
     ],
 )
 def test_crc32_xpow8n_expected(n, expected):
     assert sabyenc3.crc32_xpow8n(n) == expected
-
-
-@pytest.mark.parametrize(
-    "n",
-    [
-        -1,
-        4294967296,
-    ],
-)
-def test_crc32_xpow8n_out_of_range(n):
-    with pytest.raises(OverflowError):
-        sabyenc3.crc32_xpow8n(n)

--- a/tests/test_crc32.py
+++ b/tests/test_crc32.py
@@ -56,7 +56,7 @@ def test_crc32_zero_unpad_expected(crc1, zeroes, expected):
         (30, 2),
         (31, 1),
         (4294967295, 2147483648),
-        (4294967296, 2147483648),  # 0
+        (4294967296, 1073741824),  # 1
     ],
 )
 def test_crc32_xpown_expected(n, expected):
@@ -69,7 +69,7 @@ def test_crc32_xpown_expected(n, expected):
         (0, 2147483648),
         (1, 8388608),
         (4294967295, 2147483648),
-        (4294967296, 2147483648),  # 0
+        (4294967296, 8388608),  # 1
     ],
 )
 def test_crc32_xpow8n_expected(n, expected):

--- a/tests/test_crc32.py
+++ b/tests/test_crc32.py
@@ -56,11 +56,22 @@ def test_crc32_zero_unpad_expected(crc1, zeroes, expected):
         (30, 2),
         (31, 1),
         (4294967295, 2147483648),
-        (18446744073709551615, 2147483648),
     ],
 )
 def test_crc32_xpown_expected(n, expected):
     assert sabyenc3.crc32_xpown(n) == expected
+
+
+@pytest.mark.parametrize(
+    "n",
+    [
+        -1,
+        4294967296,
+    ],
+)
+def test_crc32_xpown_out_of_range(n):
+    with pytest.raises(OverflowError):
+        sabyenc3.crc32_xpown(n)
 
 
 @pytest.mark.parametrize(
@@ -69,9 +80,19 @@ def test_crc32_xpown_expected(n, expected):
         (0, 2147483648),
         (1, 8388608),
         (4294967295, 2147483648),
-        (18446744073709551615, 3742066410),
-        (112233445566, 1480064961),
     ],
 )
 def test_crc32_xpow8n_expected(n, expected):
     assert sabyenc3.crc32_xpow8n(n) == expected
+
+
+@pytest.mark.parametrize(
+    "n",
+    [
+        -1,
+        4294967296,
+    ],
+)
+def test_crc32_xpow8n_out_of_range(n):
+    with pytest.raises(OverflowError):
+        sabyenc3.crc32_xpow8n(n)

--- a/tests/test_crc32.py
+++ b/tests/test_crc32.py
@@ -1,0 +1,77 @@
+import pytest
+import sabyenc3
+
+
+@pytest.mark.parametrize(
+    "crc1,crc2,len2,expected",
+    [
+        (0, 0, 0, 0),
+        (4294967295, 0, 0, 4294967295),
+        (0, 4294967295, 0, 4294967295),
+        (4294967295, 4294967295, 0, 0),
+        (4, 16, 256, 2385497022),
+        (18446744073709551615, 0, 0, 4294967295),
+        (18446744073709551615, 18446744073709551615, 0, 0),
+        (100, 200, 300, 1009376567)
+    ],
+)
+def test_crc32_combine_expected(crc1, crc2, len2, expected):
+    assert sabyenc3.crc32_combine(crc1, crc2, len2) == expected
+
+
+@pytest.mark.parametrize(
+    "crc1,crc2,expected",
+    [
+        (0, 0, 0),
+        (4294967295, 0, 0),
+        (0, 4294967295, 0),
+        (4294967295, 4294967295, 1048090088),
+        (18446744073709551615, 18446744073709551615, 2496806722),
+        (100, 200, 4155012749),
+    ],
+)
+def test_crc32_multiply_expected(crc1, crc2, expected):
+    assert sabyenc3.crc32_multiply(crc1, crc2) == expected
+
+
+@pytest.mark.parametrize(
+    "crc1,zeroes,expected",
+    [
+        (0, 0, 0),
+        (4294967295, 0, 4294967295),
+        (4294967295, 4294967295, 4294967295),
+        (100, 200, 1523530880),
+    ],
+)
+def test_crc32_zero_unpad_expected(crc1, zeroes, expected):
+    assert sabyenc3.crc32_zero_unpad(crc1, zeroes) == expected
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, 2147483648),
+        (1, 1073741824),
+        (8, 8388608),
+        (30, 2),
+        (31, 1),
+        (4294967295, 2147483648),
+        (18446744073709551615, 2147483648),
+    ],
+)
+def test_crc32_xpown_expected(n, expected):
+    assert sabyenc3.crc32_xpown(n) == expected
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, 2147483648),
+        (1, 8388608),
+        (4294967295, 2147483648),
+        (18446744073709551615, 3742066410),
+        (112233445566, 1480064961),
+    ],
+)
+def test_crc32_xpow8n_expected(n, expected):
+    assert sabyenc3.crc32_xpow8n(n) == expected


### PR DESCRIPTION
It seems simple enough to use the fast CRC calculations from crcutil that use hardware features if available.

I compared no checking, _PyArg_ParseStack and PyArg_ParseTuple and their is barely any difference so went with _PyArg_ParseStack because we get the bounds and type checking.

5M rounds:

```
crc32_combine
7.757969400001457
crc32_combine_parse (this one)
7.880420399997092
crc32_combine_tuple
8.029682699998375
```

Reason for making this a draft PR is I think we may as well try and add methods for the other uses of CRC calculations:

- crc_multiply
- crc_zero_unpad
- crc_2pow

I've not dug into the crcutil interface yet, but I see yencode has a `do_crc32_zeros` method which I think is the same as the unused `crc_zero_pad` so hopefully it shouldn't be too difficult to figure out adding the unpad version.

@Safihre will you want some tests? we can only really test what happens with None arguments or an invalid number of arguments but _PyArg_ParseStack takes care of that, we could test expected CRCs but I'm not sure its necessary being one line that just passes it to crcutil.

@puzzledsab

---

It might be worth thinking of renaming this to sabutils...