### PR TITLE
From a bytearray, acquire a buffer, decode and resize the bytearray

### DIFF
--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -46,7 +46,7 @@ def test_no_filename():
 
 def test_bad_size():
     with pytest.raises(ValueError) as excinfo:
-        sabyenc3.decode_buffer(b"1234", 10)
+        sabyenc3.decode_buffer(bytearray())
     assert "Invalid data length" in str(excinfo.value)
 
 

--- a/tests/testsupport.py
+++ b/tests/testsupport.py
@@ -49,9 +49,9 @@ def correct_unknown_encoding(str_or_bytes_in):
             return str_or_bytes_in.decode(chardet.detect(str_or_bytes_in)["encoding"])
 
 
-def read_plain_yenc_file(filename: str) -> bytes:
+def read_plain_yenc_file(filename: str) -> bytearray:
     with open("tests/yencfiles/%s" % filename, "rb") as yencfile:
-        return yencfile.read()
+        return bytearray(yencfile.read())
 
 
 def read_pickle(filename):
@@ -62,11 +62,11 @@ def read_pickle(filename):
             # Reset the pointer and try again
             yencfile.seek(0)
             data_chunks, data_bytes, lines = pickle.load(yencfile, encoding="bytes")
-    return b"".join(data_chunks)
+    return bytearray(b"".join(data_chunks))
 
 
-def sabyenc3_wrapper(data: bytes):
-    filename, crc_correct = sabyenc3.decode_buffer(data, len(data))
+def sabyenc3_wrapper(data: bytearray):
+    filename, crc_correct = sabyenc3.decode_buffer(data)
     return data, correct_unknown_encoding(filename), crc_correct
 
 


### PR DESCRIPTION
Related to the discussion on #79

Should perhaps rename the method decode or decode_bytearray ?

The general flow is:
- Pass in bytearray
- Get a buffer and its size
- Release GIL
- do_decode
- Acquire GIL
- Release buffer
- Resize bytearray

It uses PyByteArray_Resize to resize the bytearray therefore we need to receive an argument of type bytearray (so it's read/write), acquire a buffer and release it before resizing.

PyByteArray_Resize only reallocates is the new size is <50% than currently allocated which is a bit smarter than the one for bytes - hence the custom method was required.

Possibly in the future if the download+decode process is simplified the bytearray wouldn't be required and instead the decoded size could be returned or decode into a new buffer. (memoryview for download => decode into memoryview/newbuffer => copy into article cache).