### PR TITLE
Fix licensing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ authors = [
     {name = "Safihre", email = "safihre@sabnzbd.org"},
 ]
 requires-python = ">=3.9"
-license = "GPL-2.0-or-later"
-license-files = ["LICENSE.md"]
+license = {text = "GPL-2.0-or-later"}
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Avoid licensing error when building:

```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```