### PR TITLE
Fix leaks in yenc and sparse dead code

### DIFF
--- a/src/sparse.cc
+++ b/src/sparse.cc
@@ -36,7 +36,6 @@ PyObject *sparse(PyObject *self, PyObject *args)
 
     PyObject *Py_file_fileno = NULL;
     PyObject *Py_file_handle = NULL;
-    PyObject *Py_file_truncate = NULL;
 
     // Accept either a file object (with fileno()) or an integer file descriptor directly
     if (!PyArg_ParseTuple(args, "OL:sparse", &Py_file, &length))
@@ -125,12 +124,10 @@ PyObject *sparse(PyObject *self, PyObject *args)
 
     Py_XDECREF(Py_file_fileno);
     Py_XDECREF(Py_file_handle);
-    Py_XDECREF(Py_file_truncate);
     Py_RETURN_NONE;
 
 error:
     Py_XDECREF(Py_file_fileno);
     Py_XDECREF(Py_file_handle);
-    Py_XDECREF(Py_file_truncate);
     return NULL;
 }

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1437,20 +1437,6 @@ struct EnumEntry {
     long value;
 };
 
-// Add a key, value to a dictionary
-static bool add_member(PyObject* dict, const char* name, PyObject* value) {
-    if (!dict || !name || !value) return false;
-
-    Py_INCREF(value);
-    if (PyDict_SetItemString(dict, name, value) < 0) {
-        Py_DECREF(value);
-        return false;
-    }
-    Py_DECREF(value);
-
-    return true;
-}
-
 // Create an int enum for a list of entries
 static PyObject* create_int_enum(const char* enum_name, const EnumEntry* entries, std::size_t count) {
     if (!enum_name || !entries) return nullptr;
@@ -1461,10 +1447,20 @@ static PyObject* create_int_enum(const char* enum_name, const EnumEntry* entries
     // Range over the entries
     for (std::size_t i = 0; i < count; ++i) {
         const auto& e = entries[i];
-        if (!add_member(members, e.name, PyLong_FromLong(e.value))) {
+
+        PyObject* value = PyLong_FromLong(e.value);
+        if (!value) {
             Py_DECREF(members);
             return nullptr;
         }
+
+        if (PyDict_SetItemString(members, e.name, value) < 0) {
+            Py_DECREF(value);
+            Py_DECREF(members);
+            return nullptr;
+        }
+
+        Py_DECREF(value);
     }
 
     PyObject* enum_module = PyImport_ImportModule("enum");

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -414,6 +414,7 @@ static inline void NNTPResponse_process_yenc_header(NNTPResponse* instance, std:
  *
  * @param instance Decoder instance whose lines list will be appended to.
  * @param line     Line contents without the trailing CRLF.
+ * @return 0 on success, or -1 on error
  */
 static int NNTPResponse_append_line(NNTPResponse* instance, std::string_view line) {
     auto py_str = decode_utf8_with_fallback(line);

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -420,7 +420,7 @@ static int NNTPResponse_append_line(NNTPResponse* instance, std::string_view lin
 
     auto py_str = decode_utf8_with_fallback(line);
     if (!py_str)
-        return -1;
+        return 0; // lines which fail to decode are ignored
 
     if (instance->lines == nullptr) {
         instance->lines = PyList_New(0);

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1494,26 +1494,39 @@ bool yenc_init(PyObject *m) {
         {"UU", 1}
     };
     PyObject* encoding_enum = create_int_enum("EncodingFormat", encoding_entries, std::size(encoding_entries));
-    if (!encoding_enum) return false;
+    if (!encoding_enum)
+        goto error;
 
     ENCODING_FORMAT_YENC = PyObject_GetAttrString(encoding_enum, "YENC");
     ENCODING_FORMAT_UU = PyObject_GetAttrString(encoding_enum, "UU");
-    if (!ENCODING_FORMAT_YENC || !ENCODING_FORMAT_UU) {
-        Py_XDECREF(encoding_enum);
-        return false;
-    }
+    if (!ENCODING_FORMAT_YENC || !ENCODING_FORMAT_UU)
+        goto error;
 
     // Add objects to module
     Py_INCREF(&DecoderType);
+    if (PyModule_AddObject(m, "Decoder", reinterpret_cast<PyObject *>(&DecoderType)) < 0) {
+        Py_DECREF(&DecoderType);
+        goto error;
+    }
+
     Py_INCREF(&NNTPResponseType);
-    if (PyModule_AddObject(m, "Decoder", reinterpret_cast<PyObject *>(&DecoderType)) < 0 ||
-        PyModule_AddObject(m, "NNTPResponse", reinterpret_cast<PyObject *>(&NNTPResponseType)) < 0 ||
-        PyModule_AddObject(m, "EncodingFormat", encoding_enum) < 0) {
-        Py_XDECREF(&DecoderType);
-        Py_XDECREF(&NNTPResponseType);
-        Py_XDECREF(encoding_enum);
-        return false;
+    if (PyModule_AddObject(m, "NNTPResponse", reinterpret_cast<PyObject *>(&NNTPResponseType)) < 0) {
+        Py_DECREF(&NNTPResponseType);
+        goto error;
+    }
+
+    // Steals reference to encoding_enum
+    if (PyModule_AddObject(m, "EncodingFormat", encoding_enum) < 0) {
+        goto error;
     }
 
     return true;
+
+error:
+    Py_XDECREF(encoding_enum);
+    Py_XDECREF(ENCODING_FORMAT_YENC);
+    Py_XDECREF(ENCODING_FORMAT_UU);
+    ENCODING_FORMAT_YENC = nullptr;
+    ENCODING_FORMAT_UU = nullptr;
+    return false;
 }

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -175,13 +175,11 @@ std::optional<uint32_t> parse_crc32(std::string_view crc32) {
  * because it can decode any byte sequence without error.
  * 
  * @param line String view containing the text to decode
- * @return PyObject* Unicode string, or nullptr if line is empty or all decoding attempts fail
+ * @return PyObject* Unicode string, or nullptr if all decoding attempts fail
  * 
  * Note: Clears Python errors internally when decoding fails.
  */
 static PyObject* decode_utf8_with_fallback(std::string_view line) {
-    if (line.empty()) return nullptr; // Ignore empty lines
-
     auto try_decode = [&](auto decoder, const char* errors = nullptr) -> PyObject* {
         PyObject* result = decoder(line.data(), line.size(), errors);
         if (!result) PyErr_Clear();
@@ -417,9 +415,12 @@ static inline void NNTPResponse_process_yenc_header(NNTPResponse* instance, std:
  * @return 0 on success, or -1 on error
  */
 static int NNTPResponse_append_line(NNTPResponse* instance, std::string_view line) {
+    if (line.empty())
+        return 0; // empty lines are ignored but not a failure
+
     auto py_str = decode_utf8_with_fallback(line);
     if (!py_str)
-        return 0; // empty lines are ignored
+        return -1;
 
     if (instance->lines == nullptr) {
         instance->lines = PyList_New(0);

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1159,6 +1159,12 @@ static PyObject* Decoder_iternext(Decoder *self)
 
 static int Decoder_init(Decoder *self, PyObject *args, PyObject *kwds)
 {
+    // __init__ may be called more than once. This object is not reinitializable.
+    if (self->data != nullptr) {
+        PyErr_SetString(PyExc_RuntimeError, "Decoder cannot be reinitialized");
+        return -1;
+    }
+
     Py_ssize_t size;
     if (!PyArg_ParseTuple(args, "n", &size))
         return -1;
@@ -1168,17 +1174,15 @@ static int Decoder_init(Decoder *self, PyObject *args, PyObject *kwds)
     if (size > YENC_MAX_PART_SIZE)
         size = YENC_MAX_PART_SIZE;
 
-    new (&self->deque) std::deque<NNTPResponse*>();
-    self->response = nullptr;
-    self->data = static_cast<char *>(malloc(size));
-    self->size = size;
-    self->consumed = 0;
-    self->position = 0;
+    self->data = static_cast<char*>(malloc(size));
     if (!self->data) {
-        self->deque.~deque();
         PyErr_NoMemory();
         return -1;
     }
+
+    self->size = size;
+    self->consumed = 0;
+    self->position = 0;
 
     return 0;
 }
@@ -1187,6 +1191,13 @@ static PyObject* Decoder_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
     auto* self = reinterpret_cast<Decoder *>(type->tp_alloc(type, 0));
     if (!self) return NULL;
+
+    new (&self->deque) std::deque<NNTPResponse*>();
+    self->response = nullptr;
+    self->data = nullptr;
+    self->size = 0;
+    self->consumed = 0;
+    self->position = 0;
 
     return reinterpret_cast<PyObject *>(self);
 }

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -434,7 +434,6 @@ static void NNTPResponse_append_line(NNTPResponse* instance, std::string_view li
  */
 static void NNTPResponse_dealloc(NNTPResponse* self)
 {
-    Py_XDECREF(self->decoder);
     Py_XDECREF(self->data);
     Py_XDECREF(self->lines);
     Py_XDECREF(self->format);
@@ -922,19 +921,6 @@ static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char*
     return read;
 }
 
-static PyObject* NNTPResponse_iternext(NNTPResponse *instance)
-{
-    const auto deque_obj = reinterpret_cast<Decoder*>(instance->decoder);
-    if (!instance->decoder || deque_obj->deque.empty())
-        return NULL;  // StopIteration
-
-    NNTPResponse* item = deque_obj->deque.front();
-    deque_obj->deque.pop_front();
-    Py_INCREF(item);  // Return a new reference
-
-    return reinterpret_cast<PyObject*>(item);
-}
-
 static inline size_t YENC_MAX_SIZE(size_t len, size_t line_size) {
     size_t ret = len * 2    /* all characters escaped */
         + 2 /* allocation for offset and that a newline may occur early */
@@ -1007,10 +993,6 @@ PyObject* yenc_encode(PyObject* self, PyObject* Py_input_string)
  *                 referenced for iteration
  */
 static void NNTPResponse_init(NNTPResponse* instance, PyObject* parent) {
-    // Iterator requires a reference back
-    instance->decoder = parent;
-    Py_INCREF(parent);
-
     // Initialise all members
     instance->data = nullptr;
     instance->lines = nullptr;
@@ -1105,7 +1087,7 @@ PyTypeObject NNTPResponseType = {
     nullptr,                             // tp_richcompare
     0,                                   // tp_weaklistoffset
     nullptr,                             // tp_iter
-    (iternextfunc)NNTPResponse_iternext, // tp_iternext
+    nullptr,                             // tp_iternext
     nullptr,                             // tp_methods
     NNTPResponse_members,                // tp_members
     NNTPResponse_gets_sets,              // tp_getset
@@ -1163,12 +1145,15 @@ static PyObject* Decoder_iter(Decoder *self)
 
 static PyObject* Decoder_iternext(Decoder *self)
 {
-    if (self->deque.empty())
-        return NULL;  // StopIteration
+    if (self->deque.empty()) {
+        PyErr_SetNone(PyExc_StopIteration);
+        return NULL;
+    }
 
     NNTPResponse* item = self->deque.front();
     self->deque.pop_front();
 
+    // Transfer ownership from deque to Python.
     return reinterpret_cast<PyObject*>(item);
 }
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1500,22 +1500,15 @@ bool yenc_init(PyObject *m) {
         goto error;
 
     // Add objects to module
-    Py_INCREF(&DecoderType);
-    if (PyModule_AddObject(m, "Decoder", reinterpret_cast<PyObject *>(&DecoderType)) < 0) {
-        Py_DECREF(&DecoderType);
+    if (PyModule_AddType(m, &DecoderType) < 0)
         goto error;
-    }
 
-    Py_INCREF(&NNTPResponseType);
-    if (PyModule_AddObject(m, "NNTPResponse", reinterpret_cast<PyObject *>(&NNTPResponseType)) < 0) {
-        Py_DECREF(&NNTPResponseType);
+    if (PyModule_AddType(m, &NNTPResponseType) < 0)
         goto error;
-    }
 
     // Steals reference to encoding_enum
-    if (PyModule_AddObject(m, "EncodingFormat", encoding_enum) < 0) {
+    if (PyModule_AddObject(m, "EncodingFormat", encoding_enum) < 0)
         goto error;
-    }
 
     return true;
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1393,7 +1393,7 @@ static PySequenceMethods Decoder_as_sequence = {
 
 PyTypeObject DecoderType = {
     PyVarObject_HEAD_INIT(nullptr, 0)
-    "sabctols.Decoder",                   // tp_name
+    "sabctools.Decoder",                  // tp_name
     sizeof(Decoder),                      // tp_basicsize
     0,                                    // tp_itemsize
     (destructor)Decoder_dealloc,          // tp_dealloc

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1520,9 +1520,7 @@ bool yenc_init(PyObject *m) {
 
 error:
     Py_XDECREF(encoding_enum);
-    Py_XDECREF(ENCODING_FORMAT_YENC);
-    Py_XDECREF(ENCODING_FORMAT_UU);
-    ENCODING_FORMAT_YENC = nullptr;
-    ENCODING_FORMAT_UU = nullptr;
+    Py_CLEAR(ENCODING_FORMAT_YENC);
+    Py_CLEAR(ENCODING_FORMAT_UU);
     return false;
 }

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -993,18 +993,10 @@ PyObject* yenc_encode(PyObject* self, PyObject* Py_input_string)
     return retval;
 }
 
-/**
- * Initializer for NNTPResponse instances used by Decoder.
- *
- * Binds the NNTPResponse to its owning Decoder and resets all parsing
- * and decoding fields to a consistent default state.
- *
- * @param instance Newly allocated NNTPResponse object to initialize
- * @param parent   Decoder object that owns this response and will be
- *                 referenced for iteration
- */
-static void NNTPResponse_init(NNTPResponse* instance, PyObject* parent) {
-    // Initialise all members
+static PyObject* NNTPResponse_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+    auto* instance = reinterpret_cast<NNTPResponse *>(type->tp_alloc(type, 0));
+    if (!instance) return nullptr;
+
     instance->data = nullptr;
     instance->lines = nullptr;
     instance->format = nullptr;
@@ -1029,6 +1021,8 @@ static void NNTPResponse_init(NNTPResponse* instance, PyObject* parent) {
     instance->has_end = false;
     instance->has_emptyline = false;
     instance->has_baddata = false;
+
+    return reinterpret_cast<PyObject *>(instance);
 }
 
 /**
@@ -1102,6 +1096,14 @@ PyTypeObject NNTPResponseType = {
     nullptr,                             // tp_methods
     NNTPResponse_members,                // tp_members
     NNTPResponse_gets_sets,              // tp_getset
+    nullptr,                             // tp_base
+    nullptr,                             // tp_dict
+    nullptr,                             // tp_descr_get
+    nullptr,                             // tp_descr_set
+    0,                                   // tp_dictoffset
+    nullptr,                             // tp_init
+    PyType_GenericAlloc,                 // tp_alloc
+    NNTPResponse_new,                    // tp_new
 };
 
 /**
@@ -1262,10 +1264,9 @@ static Py_ssize_t Decoder_len(Decoder *self)
 Py_ssize_t Decoder_decode(Decoder *self, const char* data, const Py_ssize_t size) {
     auto instance = self->response;
     if (!instance) {
-        instance = PyObject_New(NNTPResponse, &NNTPResponseType);
+        instance = reinterpret_cast<NNTPResponse *>(PyObject_CallObject(reinterpret_cast<PyObject *>(&NNTPResponseType), NULL));
         if (!instance) return -1;
         self->response = instance;
-        NNTPResponse_init(instance, reinterpret_cast<PyObject*>(self));
     }
 
     return NNTPResponse_decode_buffer(instance, data, size);;

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -1159,7 +1159,6 @@ static PyObject* Decoder_iter(Decoder *self)
 static PyObject* Decoder_iternext(Decoder *self)
 {
     if (self->deque.empty()) {
-        PyErr_SetNone(PyExc_StopIteration);
         return NULL;
     }
 

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -415,16 +415,26 @@ static inline void NNTPResponse_process_yenc_header(NNTPResponse* instance, std:
  * @param instance Decoder instance whose lines list will be appended to.
  * @param line     Line contents without the trailing CRLF.
  */
-static void NNTPResponse_append_line(NNTPResponse* instance, std::string_view line) {
+static int NNTPResponse_append_line(NNTPResponse* instance, std::string_view line) {
     auto py_str = decode_utf8_with_fallback(line);
-    if (!py_str) return;
+    if (!py_str)
+        return 0; // empty lines are ignored
 
     if (instance->lines == nullptr) {
         instance->lines = PyList_New(0);
+        if (!instance->lines) {
+            Py_DECREF(py_str);
+            return -1;
+        }
     }
 
-    PyList_Append(instance->lines, py_str);
+    if (PyList_Append(instance->lines, py_str) < 0) {
+        Py_DECREF(py_str);
+        return -1;
+    }
+
     Py_DECREF(py_str);
+    return 0;
 }
 
 /**
@@ -905,7 +915,8 @@ static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char*
 
         if (instance->format == nullptr) {
             // Format is still unknown so record lines
-            NNTPResponse_append_line(instance, line);
+            if (NNTPResponse_append_line(instance, line) < 0)
+                return -1;
         } else if (instance->format == ENCODING_FORMAT_YENC) {
             NNTPResponse_process_yenc_header(instance, line);
             if (instance->body) {

--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -631,7 +631,6 @@ static bool NNTPResponse_decode_yenc(NNTPResponse *instance, const char *buf, co
             // Release buffer to resize
             PyBuffer_Release(&dst_buf);
             if (PyByteArray_Resize(instance->data, needed) == -1) {
-                PyBuffer_Release(&dst_buf);
                 return false;
             }
 

--- a/src/yenc.h
+++ b/src/yenc.h
@@ -67,7 +67,6 @@ PyObject* yenc_encode(PyObject *, PyObject*);
 typedef struct {
     PyObject_HEAD
 
-	PyObject *decoder; // reference to parent decoder
 	PyObject* data;
 	Py_ssize_t bytes_decoded;
 	Py_ssize_t bytes_read;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -377,6 +377,5 @@ def test_parsing_crc(hex: str, expected: int):
 
 def test_no_reinitialization():
     decoder = sabctools.Decoder(0)
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(RuntimeError, match="Decoder cannot be reinitialized"):
         decoder.__init__(100)
-    assert "Decoder cannot be reinitialized" in str(excinfo.value)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -373,3 +373,10 @@ def test_parsing_crc(hex: str, expected: int):
     response = next(decoder, None)
     assert response
     assert response.crc_expected == expected
+
+
+def test_no_reinitialization():
+    decoder = sabctools.Decoder(0)
+    with pytest.raises(RuntimeError) as excinfo:
+        decoder.__init__(100)
+    assert "Decoder cannot be reinitialized" in str(excinfo.value)


### PR DESCRIPTION
Fixes issues in yenc.cc and sparse.cc listed on https://github.com/sabnzbd/sabctools/pull/185#issuecomment-4874054872

- Remove `NNTPResponse` references to parent `Decoder` and remove `NNTPResponse` as an iterator
- Prevent `Decoder` being initialized multiple times and leaking
- Minor OOM or module-init issues
  - Fix PyList_New(0) failure crash and leak
  - Fix `create_int_enum` ownership contract paths, `PyLong_FromLong` not decref'd
  - Fix module init paths leaking `ENCODING_FORMAT_*`
- Removed no-op call to `PyBuffer_Release`
- Sparse remove dead code

Maybe Claude could check?

I'll PR unlocked_ssl separately, I've not looked at it yet but I don't think it needs a release until after that.