### PR TITLE
Python 3.15 support

### DIFF
--- a/.github/workflows/ci_and_build_release.yml
+++ b/.github/workflows/ci_and_build_release.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.15-dev' ]
 
     steps:
       - uses: actions/checkout@v7

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -324,7 +324,7 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     }
 
     Py_ssl_socket = PyObject_GetAttrString(ssl_socket, "_sslobj");
-    if (!Py_ssl_socket) {
+    if (!Py_ssl_socket || Py_IsNone(Py_ssl_socket)) {
         PyErr_SetString(PyExc_ValueError, "Could not find _sslobj attribute");
         goto error;
     }

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -208,16 +208,13 @@ void openssl_init() {
 #endif
 
 cleanup:
-    Py_XDECREF(ssl_module);
-    Py_XDECREF(_ssl_module);
-    Py_XDECREF(_ssl_module_path);
+    Py_CLEAR(ssl_module);
+    Py_CLEAR(_ssl_module);
+    Py_CLEAR(_ssl_module_path);
     if (!openssl_linked()) {
-        Py_XDECREF(SSLWantReadError);
-        Py_XDECREF(SSLWantWriteError);
-        Py_XDECREF(SSLSocketType);
-        SSLWantReadError = NULL;
-        SSLWantWriteError = NULL;
-        SSLSocketType = NULL;
+        Py_CLEAR(SSLWantReadError);
+        Py_CLEAR(SSLWantWriteError);
+        Py_CLEAR(SSLSocketType);
         openssl_handle = NULL;
         SSL_read_ex = NULL;
         SSL_get_error = NULL;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -330,6 +330,7 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     Py_buffer Py_buffer;
     PyObject *retval = NULL;
     PyObject *blocking = NULL;
+    int is_blocking;
 
     if(!openssl_linked()) {
         PyErr_SetString(PyExc_OSError, "Failed to link with OpenSSL");
@@ -348,7 +349,12 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
     }
 
     blocking = PyObject_CallMethod(ssl_socket, "getblocking", NULL);
-    if (blocking == Py_True) {
+    if (!blocking)
+        goto error; // call failed
+    is_blocking = PyObject_IsTrue(blocking);
+    if (is_blocking < 0)
+        goto error;
+    if (is_blocking) {
         PyErr_SetString(PyExc_ValueError, "Only non-blocking sockets are supported");
         goto error;
     }

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -153,8 +153,6 @@ static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 
 /* Linking to OpenSSL function used by Python */
 void openssl_init() {
-    // TODO: consider adding an extra version check to avoid possible future changes to SSL_read_ex
-
     PyObject *ssl_module = NULL;
     PyObject *_ssl_module = NULL;
     PyObject *_ssl_module_path = NULL;
@@ -197,7 +195,9 @@ void openssl_init() {
     if (PyObject_HasAttrString(_ssl_module, "__file__")) {
         _ssl_module_path = PyObject_GetAttrString(_ssl_module, "__file__");
         if(!_ssl_module_path) goto error;
-        openssl_handle = dlopen(PyUnicode_AsUTF8(_ssl_module_path), RTLD_LAZY | RTLD_NOLOAD);
+        const char *path = PyUnicode_AsUTF8(_ssl_module_path);
+        if(!path) goto error;
+        openssl_handle = dlopen(path, RTLD_LAZY | RTLD_NOLOAD);
     }
 
     if(!openssl_handle) goto error;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -115,6 +115,7 @@ static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 #else
     PyObject *tmp = PyWeakref_GetObject(obj->Socket);
     if (!tmp || Py_IsNone(tmp)) {
+        PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
         return -1;
     }
 

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -49,7 +49,7 @@ typedef struct {
     int socket_type;
     PyObject *owner; /* Python level "owner" passed to servername callback */
     PyObject *server_hostname;
-#if PY_VERSION_HEX >= 0x030F0000 /* 3.15 */
+#if PY_VERSION_HEX >= SABCTOOLS_PY_HEX(3, 15)
     int got_eof_error;
 #else
     _PySSLError err; /* last seen error from various sources */
@@ -107,7 +107,7 @@ static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
         return 0;
     }
 
-#if PY_VERSION_HEX >= 0x030D0000 // 3.13+
+#if PY_VERSION_HEX >= SABCTOOLS_PY_HEX(3, 13)
     PySocketSockObject *sock = NULL;
 
     int res = PyWeakref_GetRef(obj->Socket, (PyObject **)&sock);
@@ -276,7 +276,7 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
         } while (len > 0);
         err = _PySSL_errno(retval == 0, self->ssl, retval);
         Py_END_ALLOW_THREADS;
-#if PY_VERSION_HEX < 0x030F0000  /* 3.15 */
+#if PY_VERSION_HEX < SABCTOOLS_PY_HEX(3, 15)
         self->err = err;
 #endif
 

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -156,7 +156,6 @@ void openssl_init() {
     PyObject *ssl_module = NULL;
     PyObject *_ssl_module = NULL;
     PyObject *_ssl_module_path = NULL;
-    PyObject *ssl_socket_type = NULL;
     #if defined(_WIN32) || defined(__CYGWIN__)
     HMODULE openssl_handle = NULL;
     #else
@@ -169,9 +168,8 @@ void openssl_init() {
     _ssl_module = PyImport_ImportModule("_ssl");
     if(!_ssl_module) goto cleanup;
 
-    ssl_socket_type = PyObject_GetAttrString(ssl_module, "SSLSocket");
-    if(!PyType_Check(ssl_socket_type)) goto cleanup;
-    SSLSocketType = reinterpret_cast<PyTypeObject *>(ssl_socket_type);
+    SSLSocketType = reinterpret_cast<PyTypeObject *>(PyObject_GetAttrString(ssl_module, "SSLSocket"));
+    if(!SSLSocketType || !PyType_Check(SSLSocketType)) goto cleanup;
 
     SSLWantReadError = PyObject_GetAttrString(_ssl_module, "SSLWantReadError");
     if(!SSLWantReadError) goto cleanup;
@@ -196,30 +194,31 @@ void openssl_init() {
 
     if (PyObject_HasAttrString(_ssl_module, "__file__")) {
         _ssl_module_path = PyObject_GetAttrString(_ssl_module, "__file__");
-        if(!_ssl_module_path) goto error;
+        if(!_ssl_module_path) goto cleanup;
         const char *path = PyUnicode_AsUTF8(_ssl_module_path);
-        if(!path) goto error;
+        if(!path) goto cleanup;
         openssl_handle = dlopen(path, RTLD_LAZY | RTLD_NOLOAD);
     }
 
-    if(!openssl_handle) goto error;
+    if(!openssl_handle) goto cleanup;
 
     *(void**)&SSL_read_ex = dlsym(openssl_handle, "SSL_read_ex");
     *(void**)&SSL_get_error = dlsym(openssl_handle, "SSL_get_error");
     *(void**)&SSL_get_shutdown = dlsym(openssl_handle, "SSL_get_shutdown");
-
-error:
-    if (!openssl_linked() && openssl_handle) dlclose(openssl_handle);
-    Py_XDECREF(_ssl_module_path);
 #endif
 
 cleanup:
     Py_XDECREF(ssl_module);
     Py_XDECREF(_ssl_module);
+    Py_XDECREF(_ssl_module_path);
     if (!openssl_linked()) {
-        Py_CLEAR(SSLWantReadError);
-        Py_CLEAR(SSLWantWriteError);
-        Py_CLEAR(SSLSocketType);
+        Py_XDECREF(SSLWantReadError);
+        Py_XDECREF(SSLWantWriteError);
+        Py_XDECREF(SSLSocketType);
+        SSLWantReadError = NULL;
+        SSLWantWriteError = NULL;
+        SSLSocketType = NULL;
+        openssl_handle = NULL;
         SSL_read_ex = NULL;
         SSL_get_error = NULL;
         SSL_get_shutdown = NULL;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -62,14 +62,8 @@ typedef struct {
 
 #ifdef MS_WINDOWS
 typedef SOCKET SOCKET_T;
-#       ifdef MS_WIN64
-#               define SIZEOF_SOCKET_T 8
-#       else
-#               define SIZEOF_SOCKET_T 4
-#       endif
 #else
 typedef int SOCKET_T;
-#       define SIZEOF_SOCKET_T SIZEOF_INT
 #endif
 
 typedef struct {

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -95,7 +95,6 @@ typedef enum {
 
 static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 {
-    return 0;
     if (!obj->Socket) {
         *out_sock = NULL;
         return 0;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -99,36 +99,56 @@ typedef enum {
     SOCKET_OPERATION_OK
 } timeout_state;
 
-static int
-get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
+static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 {
     *out_sock = NULL;
+
     if (!obj->Socket) {
         return 0;
     }
-    PySocketSockObject *sock;
-#if PY_VERSION_HEX >= 0x030D0000 /* 3.13 */
+
+#if PY_VERSION_HEX >= 0x030D0000 // 3.13+
+    PySocketSockObject *sock = NULL;
+
     int res = PyWeakref_GetRef(obj->Socket, (PyObject **)&sock);
     if (res < 0) {
-        return -1; /* exception already set */
+        return -1; // exception already set
     }
     if (res == 0) {
-        return -1; /* dead weakref */
+        return -1; // dead weakref
     }
+
+    // sock is a now a NEW reference
+
     if (sock->sock_fd == INVALID_SOCKET) {
         Py_DECREF(sock);
+        PyErr_SetString(PyExc_ValueError, "Socket already closed");
         return -1;
     }
-#else
-    sock = (PySocketSockObject *)PyWeakref_GetObject(obj->Socket);
-    if ((PyObject *)sock == Py_None || sock->sock_fd == INVALID_SOCKET) {
-        *out_sock = NULL;
-        return -1;
-    }
-    Py_INCREF(sock);
-#endif
+
     *out_sock = sock;
     return 1;
+#else
+    PyObject *tmp = PyWeakref_GetObject(obj->Socket);
+
+    if (tmp == Py_None) {
+        return -1;
+    }
+
+    PySocketSockObject *sock = (PySocketSockObject *)tmp;
+
+    // Promote to an owned reference
+    Py_INCREF(sock);
+
+    if (sock->sock_fd == INVALID_SOCKET) {
+        Py_DECREF(sock);
+        PyErr_SetString(PyExc_ValueError, "Socket already closed");
+        return -1;
+    }
+
+    *out_sock = sock;
+    return 1;
+#endif
 }
 
 /* Linking to OpenSSL function used by Python */

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -337,11 +337,6 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
         return NULL;
     }
 
-    if (!PyObject_TypeCheck(ssl_socket, SSLSocketType)) {
-        PyErr_Format(PyExc_TypeError, "argument 1 must be %s", SSLSocketType->tp_name);
-        return NULL;
-    }
-
     Py_ssl_socket = PyObject_GetAttrString(ssl_socket, "_sslobj");
     if (!Py_ssl_socket) {
         PyErr_SetString(PyExc_ValueError, "Could not find _sslobj attribute");

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -209,7 +209,6 @@ cleanup:
         Py_CLEAR(SSLWantReadError);
         Py_CLEAR(SSLWantWriteError);
         Py_CLEAR(SSLSocketType);
-        openssl_handle = NULL;
         SSL_read_ex = NULL;
         SSL_get_error = NULL;
         SSL_get_shutdown = NULL;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -215,9 +215,13 @@ cleanup:
     Py_XDECREF(ssl_module);
     Py_XDECREF(_ssl_module);
     if (!openssl_linked()) {
-        Py_XDECREF(SSLWantReadError);
-        Py_XDECREF(SSLWantWriteError);
-        Py_XDECREF(SSLSocketType);
+        Py_CLEAR(SSLWantReadError);
+        Py_CLEAR(SSLWantWriteError);
+        Py_CLEAR(SSLSocketType);
+        SSL_read_ex = NULL;
+        SSL_get_error = NULL;
+        SSL_get_shutdown = NULL;
+        PyErr_Clear(); // linking is optional; any failure results in openssl_linked=False
     }
 }
 

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -95,50 +95,37 @@ typedef enum {
 
 static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 {
-    *out_sock = NULL;
-
+    return 0;
     if (!obj->Socket) {
+        *out_sock = NULL;
         return 0;
     }
 
 #if PY_VERSION_HEX >= SABCTOOLS_PY_HEX(3, 13)
-    PySocketSockObject *sock = NULL;
-
+    PySocketSockObject *sock;
     int res = PyWeakref_GetRef(obj->Socket, (PyObject **)&sock);
-    if (res < 0) {
-        return -1; // exception already set
-    }
-    if (res == 0) {
-        return -1; // dead weakref
-    }
-
-    // sock is a now a NEW reference
-
-    if (sock->sock_fd == INVALID_SOCKET) {
-        Py_DECREF(sock);
-        PyErr_SetString(PyExc_ValueError, "Socket already closed");
+    if (res == 0 || sock->sock_fd == INVALID_SOCKET) {
+        Py_XDECREF(sock);
+        PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
         return -1;
     }
-
+    // sock is a now a NEW reference
     *out_sock = sock;
-    return 1;
+    return res;
 #else
     PyObject *tmp = PyWeakref_GetObject(obj->Socket);
-
-    if (tmp == Py_None) {
+    if (!tmp || Py_IsNone(tmp)) {
         return -1;
     }
 
     PySocketSockObject *sock = (PySocketSockObject *)tmp;
+    if (sock->sock_fd == INVALID_SOCKET) {
+        PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
+        return -1;
+    }
 
     // Promote to an owned reference
     Py_INCREF(sock);
-
-    if (sock->sock_fd == INVALID_SOCKET) {
-        Py_DECREF(sock);
-        PyErr_SetString(PyExc_ValueError, "Socket already closed");
-        return -1;
-    }
 
     *out_sock = sock;
     return 1;
@@ -235,7 +222,6 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
 
     PySocketSockObject *sock = NULL;
     if (get_socket(self, &sock) < 0) {
-        PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
         return NULL;
     }
 

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -49,8 +49,33 @@ typedef struct {
     int socket_type;
     PyObject *owner; /* Python level "owner" passed to servername callback */
     PyObject *server_hostname;
+#if PY_VERSION_HEX >= 0x030F0000 /* 3.15 */
+    int got_eof_error;
+#else
     _PySSLError err; /* last seen error from various sources */
+#endif
 } PySSLSocket;
+
+#ifndef INVALID_SOCKET /* MS defines this */
+#define INVALID_SOCKET (-1)
+#endif
+
+#ifdef MS_WINDOWS
+typedef SOCKET SOCKET_T;
+#       ifdef MS_WIN64
+#               define SIZEOF_SOCKET_T 8
+#       else
+#               define SIZEOF_SOCKET_T 4
+#       endif
+#else
+typedef int SOCKET_T;
+#       define SIZEOF_SOCKET_T SIZEOF_INT
+#endif
+
+typedef struct {
+    PyObject_HEAD
+    SOCKET_T sock_fd;           /* Socket file descriptor */
+} PySocketSockObject;
 
 static inline _PySSLError _PySSL_errno(int failed, void *ssl, int retcode)
 {
@@ -74,9 +99,37 @@ typedef enum {
     SOCKET_OPERATION_OK
 } timeout_state;
 
-/* Get the socket from a PySSLSocket, if it has one */
-#define GET_SOCKET(obj) ((obj)->Socket ? \
-    (PyObject *) PyWeakref_GetObject((obj)->Socket) : NULL)
+static int
+get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
+{
+    *out_sock = NULL;
+    if (!obj->Socket) {
+        return 0;
+    }
+    PySocketSockObject *sock;
+#if PY_VERSION_HEX >= 0x030D0000 /* 3.13 */
+    int res = PyWeakref_GetRef(obj->Socket, (PyObject **)&sock);
+    if (res < 0) {
+        return -1; /* exception already set */
+    }
+    if (res == 0) {
+        return -1; /* dead weakref */
+    }
+    if (sock->sock_fd == INVALID_SOCKET) {
+        Py_DECREF(sock);
+        return -1;
+    }
+#else
+    sock = (PySocketSockObject *)PyWeakref_GetObject(obj->Socket);
+    if ((PyObject *)sock == Py_None || sock->sock_fd == INVALID_SOCKET) {
+        *out_sock = NULL;
+        return -1;
+    }
+    Py_INCREF(sock);
+#endif
+    *out_sock = sock;
+    return 1;
+}
 
 /* Linking to OpenSSL function used by Python */
 void openssl_init() {
@@ -164,7 +217,12 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
     int retval;
     int sockstate;
     _PySSLError err;
-    PyObject *sock = GET_SOCKET(self);
+
+    PySocketSockObject *sock = NULL;
+    if (get_socket(self, &sock) < 0) {
+        PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
+        return NULL;
+    }
 
     mem = (char *)buffer->buf;
     if (len <= 0 || len > buffer->len) {
@@ -180,14 +238,6 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
         }
     }
 
-    if (sock != NULL) {
-        if (((PyObject*)sock) == Py_None) {
-            PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");
-            return NULL;
-        }
-        Py_INCREF(sock);
-    }
-
     do {
         Py_BEGIN_ALLOW_THREADS;
         do {
@@ -200,7 +250,9 @@ static PyObject* unlocked_ssl_recv_into_impl(PySSLSocket *self, Py_ssize_t len, 
         } while (len > 0);
         err = _PySSL_errno(retval == 0, self->ssl, retval);
         Py_END_ALLOW_THREADS;
+#if PY_VERSION_HEX < 0x030F0000  /* 3.15 */
         self->err = err;
+#endif
 
         if (count > 0) {
             break;

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -103,6 +103,7 @@ static int get_socket(PySSLSocket *obj, PySocketSockObject **out_sock)
 #if PY_VERSION_HEX >= SABCTOOLS_PY_HEX(3, 13)
     PySocketSockObject *sock;
     int res = PyWeakref_GetRef(obj->Socket, (PyObject **)&sock);
+    if (res < 0) return -1;
     if (res == 0 || sock->sock_fd == INVALID_SOCKET) {
         Py_XDECREF(sock);
         PyErr_SetString(PyExc_ValueError, "Underlying socket connection gone");

--- a/src/unlocked_ssl.cc
+++ b/src/unlocked_ssl.cc
@@ -30,7 +30,7 @@ static int (*SSL_get_error)(void*, int) = NULL;
 static int (*SSL_get_shutdown)(void*) = NULL;
 static PyObject *SSLWantReadError = NULL;
 static PyObject *SSLWantWriteError = NULL;
-static PyObject *SSLSocketType = NULL;
+static PyTypeObject *SSLSocketType = NULL;
 
 typedef struct {
     int ssl; /* last seen error from SSL */
@@ -156,6 +156,7 @@ void openssl_init() {
     PyObject *ssl_module = NULL;
     PyObject *_ssl_module = NULL;
     PyObject *_ssl_module_path = NULL;
+    PyObject *ssl_socket_type = NULL;
     #if defined(_WIN32) || defined(__CYGWIN__)
     HMODULE openssl_handle = NULL;
     #else
@@ -168,8 +169,9 @@ void openssl_init() {
     _ssl_module = PyImport_ImportModule("_ssl");
     if(!_ssl_module) goto cleanup;
 
-    SSLSocketType = PyObject_GetAttrString(ssl_module, "SSLSocket");
-    if(!SSLSocketType) goto cleanup;
+    ssl_socket_type = PyObject_GetAttrString(ssl_module, "SSLSocket");
+    if(!PyType_Check(ssl_socket_type)) goto cleanup;
+    SSLSocketType = reinterpret_cast<PyTypeObject *>(ssl_socket_type);
 
     SSLWantReadError = PyObject_GetAttrString(_ssl_module, "SSLWantReadError");
     if(!SSLWantReadError) goto cleanup;
@@ -343,6 +345,11 @@ PyObject* unlocked_ssl_recv_into(PyObject* self, PyObject* args) {
 
     // Parse input
     if (!PyArg_ParseTuple(args, "O!w*:unlocked_ssl_recv_into", SSLSocketType, &ssl_socket, &Py_buffer)) {
+        return NULL;
+    }
+
+    if (!PyObject_TypeCheck(ssl_socket, SSLSocketType)) {
+        PyErr_Format(PyExc_TypeError, "argument 1 must be %s", SSLSocketType->tp_name);
         return NULL;
     }
 

--- a/src/unlocked_ssl.h
+++ b/src/unlocked_ssl.h
@@ -19,6 +19,8 @@
 #ifndef SABCTOOLS_UNLOCKED_SSL_H
 #define SABCTOOLS_UNLOCKED_SSL_H
 
+#define SABCTOOLS_PY_HEX(major, minor) (((major) << 24) | ((minor) << 16))
+
 #include <Python.h>
 #include <stdio.h>
 #include <fcntl.h>

--- a/tests/test_unlocked_ssl.py
+++ b/tests/test_unlocked_ssl.py
@@ -312,23 +312,13 @@ def test_unlocked_ssl_recv_into_bulk_response(client):
 
 
 def test_read_after_close(client):
-    # 131072 bytes divide up into 8 TLS records (16 KB each)
-    # In nonblocking mode, we should be able to read all eight in a single
-    # drop of the GIL.
     size = 131072
     buffer = bytearray(8192)
 
     client.sendall(b"\xff" * size)
 
     select.select([client], [], [])
-    try:
-        size -= sabctools.unlocked_ssl_recv_into(client, buffer)
-    except ssl.SSLWantReadError:
-        select.select([client], [], [])
-        # Give the sender some more time to complete sending.
-        time.sleep(0.1)
     client.close()
-    assert size > 0
     with pytest.raises(ValueError, match="Could not find _sslobj attribute"):
         sabctools.unlocked_ssl_recv_into(client, buffer)
 

--- a/tests/test_unlocked_ssl.py
+++ b/tests/test_unlocked_ssl.py
@@ -311,6 +311,28 @@ def test_unlocked_ssl_recv_into_bulk_response(client):
     pytest.fail("All TLS reads were smaller than 16KB")
 
 
+def test_read_after_close(client):
+    # 131072 bytes divide up into 8 TLS records (16 KB each)
+    # In nonblocking mode, we should be able to read all eight in a single
+    # drop of the GIL.
+    size = 131072
+    buffer = bytearray(8192)
+
+    client.sendall(b"\xff" * size)
+
+    select.select([client], [], [])
+    try:
+        size -= sabctools.unlocked_ssl_recv_into(client, buffer)
+    except ssl.SSLWantReadError:
+        select.select([client], [], [])
+        # Give the sender some more time to complete sending.
+        time.sleep(0.1)
+    client.close()
+    assert size > 0
+    with pytest.raises(ValueError, match="Could not find _sslobj attribute"):
+        sabctools.unlocked_ssl_recv_into(client, buffer)
+
+
 #
 def test_unlocked_ssl_recv_into_blocking_socket_fails(client, buffer):
     with pytest.raises(ValueError, match="Only non-blocking sockets are supported"):


### PR DESCRIPTION
Fixes some issues identified in https://github.com/sabnzbd/sabctools/pull/185#issuecomment-4874054872

- Early exits; no space in buffer or too large
- Type check that we are given an SSLSocket
- getblocking check accounts for call failure
- Adds 3.15 support using PyWeakref_GetRef on 3.13+
- openssl_init single path, remove dlclose, and cleanup to prevent dangling pointers