### PR TITLE
Consistent empty file name behaviour

### DIFF
--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -354,7 +354,7 @@ static inline void NNTPResponse_process_yenc_header(NNTPResponse* instance, std:
 	    if ((pos = line.find(" name=")) != std::string::npos) {
 	        line.remove_prefix(pos + 6);
             // Strip trailing whitespace/null from filename
-            if ((pos = line.find_last_not_of('\0')) != std::string::npos) {
+            if ((pos = line.find_last_not_of(" \t\r\n\0")) != std::string::npos) {
                 Py_XDECREF(instance->file_name);
                 instance->file_name = decode_utf8_with_fallback(line.substr(0, pos + 1));
             }
@@ -749,9 +749,11 @@ static bool NNTPResponse_decode_uu(NNTPResponse* instance, std::string_view line
             trim_while(line, [](const unsigned char c){ return std::isdigit(c); }); // skip permissions
             trim_while(line, [](const unsigned char c){ return std::isspace(c); }); // skip spaces after permissions
 
-            // The rest of the line is the filename
-            Py_XDECREF(instance->file_name);
-            instance->file_name = decode_utf8_with_fallback(line);
+            // The rest of the line is the filename, strip trailing whitespace/null
+            if (std::string::size_type pos; (pos = line.find_last_not_of(" \t\r\n\0")) != std::string::npos) {
+                Py_XDECREF(instance->file_name);
+                instance->file_name = decode_utf8_with_fallback(line.substr(0, pos + 1));
+            }
 
             instance->body = true;
             return true;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -242,6 +242,18 @@ def test_uu():
     assert response.crc == 0x6BC2917D
 
 
+def test_uu_no_filename():
+    data_plain = read_uu_file("logo_full.nntp")
+    data_plain = data_plain.replace(b"begin 644 logo-full.svg", b"begin 644")
+    input = BytesIO(data_plain)
+    decoder = sabctools.Decoder(len(data_plain))
+    n = input.readinto(decoder)
+    decoder.process(n)
+    response = next(decoder, None)
+    assert response
+    assert response.file_name is None
+
+
 @pytest.mark.parametrize(
     "length",
     range(1, 46),


### PR DESCRIPTION
Restored previous behaviour that UU with empty file name should return None instead of "".
Also made both yenc/uu follow the comment and strip whitespace from the end of lines.

> Claude had 1 more small thing on the previous PR:
>
> One tiny behavior nuance worth a glance, not a defect: the empty-line special case was removed from decode_utf8_with_fallback itself (it now decodes empty input to "" rather than returning nullptr). Every call site is unaffected except one edge: a malformed UU begin line with no filename now produces file_name == "" where it previously produced None. Both are falsy, so if response.file_name: code behaves identically; only an explicit is None check would notice. Probably fine — arguably more consistent — but it's the only observable change the follow-up commits introduced beyond the fixes.