### PR TITLE
Fix yenc buffer underflow

### DIFF
--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -701,12 +701,19 @@ static bool NNTPResponse_decode_yenc(NNTPResponse *instance, const char *buf, co
         case RapidYenc::YDEC_END_CONTROL:
             // Found "\r\n=y" - likely =yend line, exit body mode
             instance->body = false;
-            read -= 2; // Back up to include "=y" for header processing
+            // Back up to include "=y" for header processing. Safe because the
+            // CRLFEQ case above leaves the "=" unconsumed, so a call can never
+            // resume on the 'y' alone: both bytes are always in this buffer.
+            read -= 2;
             break;
         case RapidYenc::YDEC_END_ARTICLE:
-            // Found ".\r\n" - NNTP article terminator, exit body mode
+            // Found "\r\n.\r\n" - NNTP article terminator, read already points
+            // past it. Nothing is gained by backing up so the line parser can
+            // rediscover the "." line; end the response here. Backing up is also
+            // not always possible, as the terminator may have started in a
+            // previous call whose bytes have since left the buffer.
             instance->body = false;
-            read -= 3; // Back up to include ".\r\n" for terminator detection
+            instance->eof = true;
             break;
     }
 
@@ -900,6 +907,7 @@ static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char*
     if (instance->body && instance->format == ENCODING_FORMAT_YENC) {
         if (!NNTPResponse_decode_yenc(instance, buf, buf_len, read)) return -1;
         if (instance->body) return read;  // Still in body, need more data
+        if (instance->eof) return read;   // Decoder consumed the article terminator
     }
 
     // Parse headers and footers line-by-line
@@ -939,6 +947,7 @@ static Py_ssize_t NNTPResponse_decode_buffer(NNTPResponse *instance, const char*
                 // =ypart was encountered, switch to body decoding
                 if (!NNTPResponse_decode_yenc(instance, buf, buf_len, read)) return -1;
                 if (instance->body) return read;  // Still decoding, need more data
+                if (instance->eof) return read;   // Decoder consumed the article terminator
             }
         } else if (instance->format == ENCODING_FORMAT_UU) {
             if (!NNTPResponse_decode_uu(instance, line)) return -1;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -453,3 +453,33 @@ def test_no_excess_allocation_multiple_responses(buffer_size):
     for response, filename in zip(responses, filenames):
         assert response.data
         assert sys.getsizeof(response.data) == sizeof_allocated_once(len(response.data)), f"{filename} was reallocated"
+
+
+@pytest.mark.parametrize("split_at", range(1, 8))
+def test_article_terminator_split(split_at: int):
+    """The yEnc decoder consumes the ".\\r\\n" terminator itself when the body runs to the
+    end of the article without a =yend line. A network read may split the input part-way
+    through that terminator, in which case the leading bytes are no longer in the buffer
+    and cannot be backed up over. The response must still be completed."""
+    data_plain = read_plain_yenc_file("test_missing_yend.yenc")
+
+    # Reference: the whole article in a single read
+    decoder = sabctools.Decoder(len(data_plain))
+    decoder.process(BytesIO(data_plain).readinto(decoder))
+    expected = next(decoder, None)
+    assert expected
+    assert expected.data
+
+    decoder = sabctools.Decoder(len(data_plain))
+    responses = []
+    for part in (data_plain[:-split_at], data_plain[-split_at:]):
+        input = BytesIO(part)
+        n = input.readinto(decoder)
+        decoder.process(n)
+        responses.extend(decoder)
+
+    # Splitting the read must not change the outcome
+    assert len(responses) == 1
+    assert responses[0].status_code == expected.status_code
+    assert responses[0].data == expected.data
+    assert responses[0].bytes_read == expected.bytes_read == len(data_plain)


### PR DESCRIPTION
Fixes an issue in the `RapidYenc::YDEC_END_ARTICLE` path, rare due to malformed yenc articles - incomplete upload for example