### PR TITLE
Avoid overallocation for yenc decoding

### DIFF
--- a/src/yenc.cc
+++ b/src/yenc.cc
@@ -587,13 +587,14 @@ static bool NNTPResponse_decode_yenc(NNTPResponse *instance, const char *buf, co
 
     if (instance->data == nullptr) {
         // Allocate output buffer on first decode call
-        // Use size from headers, capped at YENC_MAX_PART_SIZE for safety
+        // Use size from headers, capped at YENC_MAX_PART_SIZE for safety.
+        // Size this as tightly as the headers allow: the buffer is handed to the
+        // caller as-is and can never be shrunk afterwards, because
+        // PyByteArray_Resize only reallocates on a downsize below half the
+        // allocation. Anything allocated beyond bytes_decoded is retained for
+        // the lifetime of the article.
         Py_ssize_t base = instance->part_size > 0 ? instance->part_size : instance->file_size;
         Py_ssize_t expected = base + 64;  // small margin to see the end of yEnc data
-        // Round up to next multiple of CHUNK
-        expected = ((expected + CHUNK - 1) / CHUNK) * CHUNK;
-        // Add an extra CHUNK so we should never need to resize
-        expected += CHUNK;
 
         if (expected < YENC_MIN_BUFFER_SIZE)
             expected = YENC_MIN_BUFFER_SIZE;
@@ -618,28 +619,40 @@ static bool NNTPResponse_decode_yenc(NNTPResponse *instance, const char *buf, co
     // Main decode loop
     while (read < buf_len) {
         Py_ssize_t chunk_in = std::min(CHUNK, buf_len - read);
+        Py_ssize_t space = PyByteArray_GET_SIZE(instance->data) - instance->bytes_decoded;
 
-        // Ensure buffer has enough space
-        Py_ssize_t needed = instance->bytes_decoded + chunk_in;
-        Py_ssize_t current = PyByteArray_GET_SIZE(instance->data);
+        if (space < chunk_in) {
+            // The decoder never writes more bytes than it reads, so any chunk
+            // that fits in the remaining space can be decoded in place. Prefer
+            // trimming the chunk over growing the buffer: growing over-allocates
+            // and that slack can never be handed back (see above), so it would
+            // become permanent overhead on every decoded article.
+            if (space > 0) {
+                chunk_in = space;
+            } else {
+                // Out of room: the article holds more data than its headers declared.
+                // chunk_in is the tightest cheap bound on what this response can still
+                // produce, since the decoder never writes more bytes than it reads. It
+                // may over-shoot when the buffer also holds later responses, but only
+                // ever by less than one chunk.
+                Py_ssize_t needed = instance->bytes_decoded + chunk_in;
+                if (needed > YENC_MAX_PART_SIZE) {
+                    PyBuffer_Release(&dst_buf);
+                    PyErr_SetString(PyExc_BufferError, "Maximum data buffer size exceeded");
+                    return false;
+                }
 
-        if (needed > current) {
-            if (needed > YENC_MAX_PART_SIZE) {
+                // Release buffer to resize
                 PyBuffer_Release(&dst_buf);
-                PyErr_SetString(PyExc_BufferError, "Maximum data buffer size exceeded");
-                return false;
-            }
+                if (PyByteArray_Resize(instance->data, needed) == -1) {
+                    return false;
+                }
 
-            // Release buffer to resize
-            PyBuffer_Release(&dst_buf);
-            if (PyByteArray_Resize(instance->data, needed) == -1) {
-                return false;
+                // Re-pin buffer after resize
+                if (PyObject_GetBuffer(instance->data, &dst_buf, PyBUF_WRITABLE) < 0)
+                    return false;
+                data_ptr = static_cast<char*>(dst_buf.buf);
             }
-
-            // Re-pin buffer after resize
-            if (PyObject_GetBuffer(instance->data, &dst_buf, PyBUF_WRITABLE) < 0)
-                return false;
-            data_ptr = static_cast<char*>(dst_buf.buf);
         }
 
         const char *src = buf + read;

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -391,3 +391,59 @@ def test_no_reinitialization():
     decoder = sabctools.Decoder(0)
     with pytest.raises(RuntimeError, match="Decoder cannot be reinitialized"):
         decoder.__init__(100)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "test_regular.yenc",
+        "test_regular_2.yenc",
+        "test_bad_crc.yenc",
+        "test_padded_crc.yenc",
+        "test_article.yenc",
+    ],
+)
+def test_no_excess_allocation(filename: str):
+    """The decoded bytearray is handed straight to the caller and kept for the lifetime
+    of the article, so it must not hold on to a large over-allocation. It can never be
+    given back later: PyByteArray_Resize only reallocates on a downsize below half the
+    allocation, so anything allocated beyond bytes_decoded is retained permanently."""
+    data_plain = read_plain_yenc_file(filename)
+    input = BytesIO(data_plain)
+    decoder = sabctools.Decoder(len(data_plain))
+    n = input.readinto(decoder)
+    decoder.process(n)
+
+    response = next(decoder, None)
+    assert response
+    assert response.data
+
+    # Capacity of the bytearray, excluding the fixed object header
+    capacity = sys.getsizeof(response.data) - sys.getsizeof(bytearray())
+    slack = capacity - len(response.data)
+    assert slack <= 1024, f"{filename}: {slack} bytes over-allocated for {len(response.data)} bytes of data"
+
+
+@pytest.mark.parametrize("buffer_size", [1024, 64 * 1024, 512 * 1024, None])
+def test_no_excess_allocation_multiple_responses(buffer_size):
+    """Input regularly spans several responses, so the tail of one response sits in the
+    same buffer as the whole of the next. That trailing data must not drive the size of
+    this response's buffer: each response is allocated once, at part_size + 64, and
+    never resized. A slack of exactly 64 proves no reallocation happened, since growth
+    over-allocates ~12.5% and a grow-then-shrink would land on an exact fit instead."""
+    filenames = ["test_regular.yenc", "test_regular_2.yenc", "test_bad_crc.yenc", "test_padded_crc.yenc"]
+    payload = b"".join(read_plain_yenc_file(f) for f in filenames)
+
+    input = BytesIO(payload)
+    decoder = sabctools.Decoder(buffer_size or len(payload))
+    responses = []
+    while (n := input.readinto(decoder)) != 0:
+        decoder.process(n)
+        responses.extend(decoder)
+
+    assert len(responses) == len(filenames)
+    for response, filename in zip(responses, filenames):
+        assert response.data
+        capacity = sys.getsizeof(response.data) - sys.getsizeof(bytearray())
+        # +1 for the NUL byte bytearray always keeps
+        assert capacity == len(response.data) + 65, f"{filename} was reallocated"

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -393,6 +393,19 @@ def test_no_reinitialization():
         decoder.__init__(100)
 
 
+def sizeof_allocated_once(size: int) -> int:
+    """sys.getsizeof of a bytearray that went through the same allocation sequence the
+    decoder performs for a well-formed article, and nothing else: allocated at
+    part_size + 64 by decode_yenc, then resized to bytes_decoded by Decoder_process.
+
+    Reproducing the sequence rather than computing a capacity from the object header
+    keeps this independent of how a given CPython lays out or over-allocates bytearrays.
+    A buffer that was grown along the way ends up a different size."""
+    reference = bytearray(size + 64)
+    del reference[size:]
+    return sys.getsizeof(reference)
+
+
 @pytest.mark.parametrize(
     "filename",
     [
@@ -417,11 +430,7 @@ def test_no_excess_allocation(filename: str):
     response = next(decoder, None)
     assert response
     assert response.data
-
-    # Capacity of the bytearray, excluding the fixed object header
-    capacity = sys.getsizeof(response.data) - sys.getsizeof(bytearray())
-    slack = capacity - len(response.data)
-    assert slack <= 1024, f"{filename}: {slack} bytes over-allocated for {len(response.data)} bytes of data"
+    assert sys.getsizeof(response.data) == sizeof_allocated_once(len(response.data)), filename
 
 
 @pytest.mark.parametrize("buffer_size", [1024, 64 * 1024, 512 * 1024, None])
@@ -429,8 +438,7 @@ def test_no_excess_allocation_multiple_responses(buffer_size):
     """Input regularly spans several responses, so the tail of one response sits in the
     same buffer as the whole of the next. That trailing data must not drive the size of
     this response's buffer: each response is allocated once, at part_size + 64, and
-    never resized. A slack of exactly 64 proves no reallocation happened, since growth
-    over-allocates ~12.5% and a grow-then-shrink would land on an exact fit instead."""
+    never grown."""
     filenames = ["test_regular.yenc", "test_regular_2.yenc", "test_bad_crc.yenc", "test_padded_crc.yenc"]
     payload = b"".join(read_plain_yenc_file(f) for f in filenames)
 
@@ -444,6 +452,4 @@ def test_no_excess_allocation_multiple_responses(buffer_size):
     assert len(responses) == len(filenames)
     for response, filename in zip(responses, filenames):
         assert response.data
-        capacity = sys.getsizeof(response.data) - sys.getsizeof(bytearray())
-        # +1 for the NUL byte bytearray always keeps
-        assert capacity == len(response.data) + 65, f"{filename} was reallocated"
+        assert sys.getsizeof(response.data) == sizeof_allocated_once(len(response.data)), f"{filename} was reallocated"


### PR DESCRIPTION
Currently overallocates decoded data size, usually wasting 10-20%.
This matters because a 1GB article cache is effectively 1.2GB and 4GB is 4.8GB

```
                        before              after
test_regular.yenc       waste 74753 (19.5%)  →  65 (0.0%)
test_bad_crc.yenc       waste 83969 (10.9%)  →  65 (0.0%)
test_padded_crc.yenc    waste 114689 (28.0%) →  65 (0.0%)
```